### PR TITLE
Refactor to use TransactionProcessor.Client

### DIFF
--- a/EstateManagementUI.BusinessLogic.Tests/ApiClientTests.cs
+++ b/EstateManagementUI.BusinessLogic.Tests/ApiClientTests.cs
@@ -1,10 +1,4 @@
-﻿using EstateManagement.Client;
-using EstateManagement.DataTransferObjects.Requests.Merchant;
-using EstateManagement.DataTransferObjects.Requests.Operator;
-using EstateManagement.DataTransferObjects.Responses.Contract;
-using EstateManagement.DataTransferObjects.Responses.Merchant;
-using EstateManagement.DataTransferObjects.Responses.Operator;
-using EstateManagementUI.BusinessLogic.Clients;
+﻿using EstateManagementUI.BusinessLogic.Clients;
 using EstateManagementUI.BusinessLogic.Models;
 using EstateManagementUI.Pages.Merchant;
 using EstateManagementUI.Testing;
@@ -15,6 +9,12 @@ using Moq;
 using Shared.Logger;
 using Shouldly;
 using SimpleResults;
+using TransactionProcessor.Client;
+using TransactionProcessor.DataTransferObjects.Requests.Merchant;
+using TransactionProcessor.DataTransferObjects.Requests.Operator;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
+using TransactionProcessor.DataTransferObjects.Responses.Merchant;
+using TransactionProcessor.DataTransferObjects.Responses.Operator;
 using CreateMerchantModel = EstateManagementUI.BusinessLogic.Models.CreateMerchantModel;
 using SettlementSchedule = EstateManagementUI.BusinessLogic.Models.SettlementSchedule;
 
@@ -22,24 +22,24 @@ namespace EstateManagementUI.BusinessLogic.Tests;
 
 public class ApiClientTests {
     private readonly IApiClient ApiClient;
-    private readonly Mock<IEstateClient> EstateClient;
+    private readonly Mock<ITransactionProcessorClient> TransactionProcessorClient;
     private readonly Mock<IFileProcessorClient> FileProcessorClient;
     private readonly Mock<IEstateReportingApiClient> EstateReportingApiClient;
 
     public ApiClientTests() {
         Logger.Initialise(NullLogger.Instance);
 
-        this.EstateClient = new Mock<IEstateClient>();
+        this.TransactionProcessorClient = new Mock<ITransactionProcessorClient>();
         this.FileProcessorClient = new Mock<IFileProcessorClient>();
         this.EstateReportingApiClient = new Mock<IEstateReportingApiClient>();
 
-        this.ApiClient = new ApiClient(this.EstateClient.Object, this.FileProcessorClient.Object, this.EstateReportingApiClient.Object);
+        this.ApiClient = new ApiClient(this.TransactionProcessorClient.Object, this.FileProcessorClient.Object, this.EstateReportingApiClient.Object);
     }
 
 
     [Fact]
     public async Task ApiClient_GetEstate_EstateReturned() {
-        this.EstateClient.Setup(e => e.GetEstate(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+        this.TransactionProcessorClient.Setup(e => e.GetEstate(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(TestData.EstateResponse));
 
         var result= await this.ApiClient.GetEstate(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
@@ -51,7 +51,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_GetEstate_ClientCallFailed_ResultFailed()
     {
-        this.EstateClient.Setup(e => e.GetEstate(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+        this.TransactionProcessorClient.Setup(e => e.GetEstate(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
         var result = await this.ApiClient.GetEstate(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -60,7 +60,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_GetEstate_ClientCallThrewException_ResultFailed()
     {
-        this.EstateClient.Setup(e => e.GetEstate(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
+        this.TransactionProcessorClient.Setup(e => e.GetEstate(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
 
         var result = await this.ApiClient.GetEstate(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -68,7 +68,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_GetMerchants_MerchantsReturned() {
-        this.EstateClient.Setup(e => e.GetMerchants(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantResponses));
+        this.TransactionProcessorClient.Setup(e => e.GetMerchants(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantResponses));
 
         var result = await this.ApiClient.GetMerchants(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
@@ -85,7 +85,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_GetMerchants_ClientCallFailed_ResultFailed()
     {
-        this.EstateClient.Setup(e => e.GetMerchants(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+        this.TransactionProcessorClient.Setup(e => e.GetMerchants(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
         Result<List<MerchantModel>> result = await this.ApiClient.GetMerchants(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -93,7 +93,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_GetMerchant_ClientCallFailed_ResultFailed() {
-        this.EstateClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+        this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
         Result<MerchantModel> result = await this.ApiClient.GetMerchant(TestData.AccessToken, Guid.NewGuid(), Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -101,7 +101,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_GetMerchant_MerchantReturned() {
-        this.EstateClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantResponse));
+        this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantResponse));
 
         var result= await this.ApiClient.GetMerchant(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, TestData.Merchant1Id, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
@@ -110,7 +110,7 @@ public class ApiClientTests {
     
     [Fact]
     public async Task ApiClient_GetOperators_OperatorsReturned() {
-        this.EstateClient.Setup(e => e.GetOperators(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.OperatorResponses));
+        this.TransactionProcessorClient.Setup(e => e.GetOperators(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.OperatorResponses));
         
         var result = await this.ApiClient.GetOperators(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
@@ -126,7 +126,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_GetOperators_ClientCallFailed_ResultFailed() {
-        this.EstateClient.Setup(e => e.GetOperators(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+        this.TransactionProcessorClient.Setup(e => e.GetOperators(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
 
         Result<List<OperatorModel>> result = await this.ApiClient.GetOperators(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
@@ -135,7 +135,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_GetOperator_OperatorIsReturned() {
-        this.EstateClient.Setup(e => e.GetOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.OperatorResponse));
+        this.TransactionProcessorClient.Setup(e => e.GetOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.OperatorResponse));
         
         OperatorModel @operator = await this.ApiClient.GetOperator(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, TestData.Operator1Id, CancellationToken.None);
 
@@ -144,7 +144,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_GetOperator_ClientCallFailed_ResultFailed() {
-        this.EstateClient.Setup(e => e.GetOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+        this.TransactionProcessorClient.Setup(e => e.GetOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
         
         Result<OperatorModel> result = await this.ApiClient.GetOperator(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, TestData.Operator1Id, CancellationToken.None);
 
@@ -153,7 +153,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_GetContracts_ContractsReturned() {
-        this.EstateClient.Setup(e => e.GetContracts(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractResponses));
+        this.TransactionProcessorClient.Setup(e => e.GetContracts(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractResponses));
 
 
         var result = await this.ApiClient.GetContracts(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
@@ -172,7 +172,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_GetContracts_ClientCallFailed_ResultFailed()
     {
-        this.EstateClient.Setup(e => e.GetContracts(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+        this.TransactionProcessorClient.Setup(e => e.GetContracts(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
         var result = await this.ApiClient.GetContracts(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -180,7 +180,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_GetContract_ContractIsReturned() {
-        this.EstateClient.Setup(e => e.GetContract(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractResponse1));
+        this.TransactionProcessorClient.Setup(e => e.GetContract(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractResponse1));
         
         var result = await this.ApiClient.GetContract(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, TestData.Contract1Id, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
@@ -198,7 +198,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_GetContract_ClientCallFailed_ResultFailed()
     {
-        this.EstateClient.Setup(e => e.GetContract(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+        this.TransactionProcessorClient.Setup(e => e.GetContract(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
 
         var result= await this.ApiClient.GetContract(TestData.AccessToken, Guid.NewGuid(), TestData.EstateId, TestData.Contract1Id, CancellationToken.None);
@@ -208,7 +208,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_CreateOperator_OperatorIsCreated() {
-        this.EstateClient.Setup(e => e.CreateOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+        this.TransactionProcessorClient.Setup(e => e.CreateOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
         CreateOperatorModel createOperatorModel = new() { RequireCustomMerchantNumber = TestData.RequireCustomMerchantNumber, RequireCustomTerminalNumber = TestData.RequireCustomTerminalNumber, OperatorName = TestData.Operator1Name, OperatorId = TestData.Operator1Id };
 
@@ -220,7 +220,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_CreateOperator_ErrorAtServer_OperatorIsNotCreated() {
         Logger.Initialise(NullLogger.Instance);
-        this.EstateClient.Setup(e => e.CreateOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+        this.TransactionProcessorClient.Setup(e => e.CreateOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
         CreateOperatorModel createOperatorModel = new() { RequireCustomMerchantNumber = TestData.RequireCustomMerchantNumber, RequireCustomTerminalNumber = TestData.RequireCustomTerminalNumber, OperatorName = TestData.Operator1Name, OperatorId = TestData.Operator1Id };
 
@@ -231,7 +231,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_UpdateOperator_OperatorIsUpdated() {
-        this.EstateClient.Setup(e => e.UpdateOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UpdateOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
+        this.TransactionProcessorClient.Setup(e => e.UpdateOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UpdateOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
 
         UpdateOperatorModel updateOperatorModel = new() { RequireCustomMerchantNumber = TestData.RequireCustomMerchantNumber, RequireCustomTerminalNumber = TestData.RequireCustomTerminalNumber, OperatorName = TestData.Operator1Name, OperatorId = TestData.Operator1Id };
 
@@ -242,7 +242,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_UpdateOperator_ErrorAtServer_OperatorIsNotUpdated() {
-        this.EstateClient.Setup(e => e.UpdateOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UpdateOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+        this.TransactionProcessorClient.Setup(e => e.UpdateOperator(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UpdateOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
         UpdateOperatorModel updateOperatorModel = new() { RequireCustomMerchantNumber = TestData.RequireCustomMerchantNumber, RequireCustomTerminalNumber = TestData.RequireCustomTerminalNumber, OperatorName = TestData.Operator1Name, OperatorId = TestData.Operator1Id };
 
@@ -486,7 +486,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_CreateMerchant_DataIsReturned() {
-        this.EstateClient.Setup(e => e.CreateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateMerchantRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+        this.TransactionProcessorClient.Setup(e => e.CreateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateMerchantRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
         Result result = await this.ApiClient.CreateMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.CreateMerchantModel(SettlementSchedule.Immediate), CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
@@ -494,7 +494,7 @@ public class ApiClientTests {
 
     [Fact]
     public async Task ApiClient_CreateMerchant_ErrorAtServer_NoDataIsReturned() {
-        this.EstateClient.Setup(e => e.CreateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateMerchantRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+        this.TransactionProcessorClient.Setup(e => e.CreateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateMerchantRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
         Result result = await this.ApiClient.CreateMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.CreateMerchantModel(SettlementSchedule.Immediate), CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -503,7 +503,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_CreateMerchant_ClientThrowsException_ResultIsFailed()
     {
-        this.EstateClient.Setup(e => e.CreateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateMerchantRequest>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
+        this.TransactionProcessorClient.Setup(e => e.CreateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CreateMerchantRequest>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
 
         Result result = await this.ApiClient.CreateMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.CreateMerchantModel(SettlementSchedule.Immediate), CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -512,7 +512,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_UpdateMerchant_MerchantIsUpdated()
     {
-        this.EstateClient.Setup(e => e.UpdateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UpdateMerchantRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+        this.TransactionProcessorClient.Setup(e => e.UpdateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UpdateMerchantRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
         Result result = await this.ApiClient.UpdateMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id, TestData.UpdateMerchantModel(SettlementSchedule.Immediate), CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
@@ -521,7 +521,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_UpdateMerchant_ErrorAtServer_ResultIsFailed()
     {
-        this.EstateClient.Setup(e => e.UpdateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UpdateMerchantRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+        this.TransactionProcessorClient.Setup(e => e.UpdateMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UpdateMerchantRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
         Result result = await this.ApiClient.UpdateMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id, TestData.UpdateMerchantModel(SettlementSchedule.Immediate), CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -530,7 +530,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_UpdateMerchantAddress_MerchantAddressIsUpdated()
     {
-        this.EstateClient.Setup(e => e.UpdateMerchantAddress(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Address>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+        this.TransactionProcessorClient.Setup(e => e.UpdateMerchantAddress(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Address>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
         Result result = await this.ApiClient.UpdateMerchantAddress(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id, TestData.AddressModel, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
@@ -539,7 +539,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_UpdateMerchantAddress_ErrorAtServer_ResultIsFailed()
     {
-        this.EstateClient.Setup(e => e.UpdateMerchantAddress(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Address>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+        this.TransactionProcessorClient.Setup(e => e.UpdateMerchantAddress(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Address>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
         Result result = await this.ApiClient.UpdateMerchantAddress(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id, TestData.AddressModel, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -548,7 +548,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_UpdateMerchantContact_MerchantContactIsUpdated()
     {
-        this.EstateClient.Setup(e => e.UpdateMerchantContact(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Contact>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+        this.TransactionProcessorClient.Setup(e => e.UpdateMerchantContact(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Contact>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
         Result result = await this.ApiClient.UpdateMerchantContact(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id, TestData.ContactModel, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
@@ -557,7 +557,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_UpdateMerchantContact_ErrorAtServer_ResultIsFailed()
     {
-        this.EstateClient.Setup(e => e.UpdateMerchantContact(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Contact>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+        this.TransactionProcessorClient.Setup(e => e.UpdateMerchantContact(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Contact>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
         Result result = await this.ApiClient.UpdateMerchantContact(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id, TestData.ContactModel, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -566,7 +566,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_AssignContractToMerchant_ContractAssigned()
     {
-        this.EstateClient.Setup(e => e.AddContractToMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<AddMerchantContractRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+        this.TransactionProcessorClient.Setup(e => e.AddContractToMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<AddMerchantContractRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
         Result result = await this.ApiClient.AssignContractToMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id,
             TestData.AssignContractToMerchantModel, CancellationToken.None);
@@ -576,7 +576,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_AssignContractToMerchant_ClientCallFailed_ResultIsFailed()
     {
-        this.EstateClient.Setup(e => e.AddContractToMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<AddMerchantContractRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+        this.TransactionProcessorClient.Setup(e => e.AddContractToMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<AddMerchantContractRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
         Result result = await this.ApiClient.AssignContractToMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id,
             TestData.AssignContractToMerchantModel, CancellationToken.None);
@@ -586,7 +586,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_RemoveContractFromMerchant_ContractRemoved()
     {
-        this.EstateClient.Setup(e => e.RemoveContractFromMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+        this.TransactionProcessorClient.Setup(e => e.RemoveContractFromMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
         Result result = await this.ApiClient.RemoveContractFromMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id,
             TestData.Contract1Id, CancellationToken.None);
@@ -596,7 +596,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_RemoveContractFromMerchant_ClientCallFailed_ResultIsFailed()
     {
-        this.EstateClient.Setup(e => e.RemoveContractFromMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+        this.TransactionProcessorClient.Setup(e => e.RemoveContractFromMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
         Result result = await this.ApiClient.RemoveContractFromMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id,
             TestData.Contract1Id, CancellationToken.None);
@@ -606,7 +606,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_AssignOperatorToMerchant_OperatorAssigned()
     {
-        this.EstateClient.Setup(e => e.AssignOperatorToMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<AssignOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+        this.TransactionProcessorClient.Setup(e => e.AssignOperatorToMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<AssignOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
         Result result = await this.ApiClient.AssignOperatorToMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id,
             TestData.AssignOperatorToMerchantModel, CancellationToken.None);
@@ -616,7 +616,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_AssignOperatorToMerchant_ClientCallFailed_ResultIsFailed()
     {
-        this.EstateClient.Setup(e => e.AssignOperatorToMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<AssignOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+        this.TransactionProcessorClient.Setup(e => e.AssignOperatorToMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<AssignOperatorRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
         Result result = await this.ApiClient.AssignOperatorToMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id,
             TestData.AssignOperatorToMerchantModel, CancellationToken.None);
@@ -626,7 +626,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_RemoveOperatorFromMerchant_OperatorRemoved()
     {
-        this.EstateClient.Setup(e => e.RemoveOperatorFromMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+        this.TransactionProcessorClient.Setup(e => e.RemoveOperatorFromMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
         Result result = await this.ApiClient.RemoveOperatorFromMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id,
             TestData.Operator1Id, CancellationToken.None);
@@ -636,7 +636,7 @@ public class ApiClientTests {
     [Fact]
     public async Task ApiClient_RemoveOperatorFromMerchant_ClientCallFailed_ResultIsFailed()
     {
-        this.EstateClient.Setup(e => e.RemoveOperatorFromMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+        this.TransactionProcessorClient.Setup(e => e.RemoveOperatorFromMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
         Result result = await this.ApiClient.RemoveOperatorFromMerchant(TestData.AccessToken, Guid.Empty, TestData.EstateId, TestData.Merchant1Id,
             TestData.Operator1Id, CancellationToken.None);

--- a/EstateManagementUI.BusinessLogic.Tests/ModelFactoryTests.cs
+++ b/EstateManagementUI.BusinessLogic.Tests/ModelFactoryTests.cs
@@ -1,19 +1,15 @@
-﻿using EstateManagement.DataTransferObjects.Requests.Merchant;
-using EstateManagement.DataTransferObjects.Responses.Estate;
-using EstateManagement.DataTransferObjects.Responses.Merchant;
-using EstateManagementUI.Testing;
+﻿using EstateManagementUI.Testing;
 using EstateManagementUI.BusinessLogic.Models;
 using Shouldly;
 using EstateManagementUI.BusinessLogic.Common;
-using EstateManagement.DataTransferObjects.Responses.Operator;
-using SimpleResults;
-using EstateManagement.DataTransferObjects.Responses.Contract;
 using EstateReportingAPI.DataTransferObjects;
 using FileProcessor.DataTransferObjects.Responses;
-using EstateManagementUI.ViewModels;
 using EstateReportingAPI.DataTrasferObjects;
-using ContractProduct = EstateManagement.DataTransferObjects.Responses.Contract.ContractProduct;
-using ContractProductTransactionFee = EstateManagement.DataTransferObjects.Responses.Contract.ContractProductTransactionFee;
+using TransactionProcessor.DataTransferObjects.Requests.Merchant;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
+using TransactionProcessor.DataTransferObjects.Responses.Estate;
+using TransactionProcessor.DataTransferObjects.Responses.Merchant;
+using TransactionProcessor.DataTransferObjects.Responses.Operator;
 using FileImportLogList = FileProcessor.DataTransferObjects.Responses.FileImportLogList;
 using FileLineProcessingResult = FileProcessor.DataTransferObjects.Responses.FileLineProcessingResult;
 using LastSettlement = EstateReportingAPI.DataTransferObjects.LastSettlement;
@@ -592,22 +588,22 @@ namespace EstateManagementUI.BusinessLogic.Tests {
         }
 
         [Theory]
-        [InlineData(Models.SettlementSchedule.Immediate, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Immediate)]
-        [InlineData(Models.SettlementSchedule.Monthly, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Monthly)]
-        [InlineData(Models.SettlementSchedule.Weekly, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Weekly)]
-        [InlineData((Models.SettlementSchedule)99, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Immediate)]
+        [InlineData(Models.SettlementSchedule.Immediate, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Immediate)]
+        [InlineData(Models.SettlementSchedule.Monthly, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Monthly)]
+        [InlineData(Models.SettlementSchedule.Weekly, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Weekly)]
+        [InlineData((Models.SettlementSchedule)99, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Immediate)]
         public void ModelFactory_ConvertFrom_SettlementSchedule_IsConverted(Models.SettlementSchedule settlementSchedule,
-                                                                            EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule expectedResult) {
-            EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule result = ModelFactory.ConvertFrom(settlementSchedule);
+                                                                            TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule expectedResult) {
+            TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule result = ModelFactory.ConvertFrom(settlementSchedule);
             result.ShouldBe(expectedResult);
         }
 
         [Theory]
-        [InlineData(BusinessLogic.Models.SettlementSchedule.Immediate, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Immediate)]
-        [InlineData(BusinessLogic.Models.SettlementSchedule.Weekly, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Weekly)]
-        [InlineData(BusinessLogic.Models.SettlementSchedule.Monthly, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Monthly)]
+        [InlineData(BusinessLogic.Models.SettlementSchedule.Immediate, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Immediate)]
+        [InlineData(BusinessLogic.Models.SettlementSchedule.Weekly, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Weekly)]
+        [InlineData(BusinessLogic.Models.SettlementSchedule.Monthly, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Monthly)]
         public void ModelFactory_ConvertFrom_CreateMerchantModel_ModelIsConverted(BusinessLogic.Models.SettlementSchedule settlementSchedule,
-                                                                                  EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule expectedSettlementSchedule) {
+                                                                                  TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule expectedSettlementSchedule) {
             CreateMerchantModel model = TestData.CreateMerchantModel(settlementSchedule);
 
             CreateMerchantRequest request = ModelFactory.ConvertFrom(model);
@@ -689,11 +685,11 @@ namespace EstateManagementUI.BusinessLogic.Tests {
         }
 
         [Theory]
-        [InlineData(BusinessLogic.Models.SettlementSchedule.Immediate, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Immediate)]
-        [InlineData(BusinessLogic.Models.SettlementSchedule.Weekly, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Weekly)]
-        [InlineData(BusinessLogic.Models.SettlementSchedule.Monthly, EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule.Monthly)]
+        [InlineData(BusinessLogic.Models.SettlementSchedule.Immediate, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Immediate)]
+        [InlineData(BusinessLogic.Models.SettlementSchedule.Weekly, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Weekly)]
+        [InlineData(BusinessLogic.Models.SettlementSchedule.Monthly, TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Monthly)]
         public void ModelFactory_ConvertFrom_UpdateMerchantModel_ModelIsConverted(BusinessLogic.Models.SettlementSchedule settlementSchedule,
-                                                                                  EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule expectedSettlementSchedule) {
+                                                                                  TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule expectedSettlementSchedule) {
             UpdateMerchantModel model = TestData.UpdateMerchantModel(settlementSchedule);
 
             var request = ModelFactory.ConvertFrom(model);

--- a/EstateManagementUI.BusinessLogic/Clients/ApiClient.cs
+++ b/EstateManagementUI.BusinessLogic/Clients/ApiClient.cs
@@ -1,12 +1,4 @@
-﻿using EstateManagement.Client;
-using EstateManagement.DataTransferObjects.Requests.Contract;
-using EstateManagement.DataTransferObjects.Requests.Merchant;
-using EstateManagement.DataTransferObjects.Requests.Operator;
-using EstateManagement.DataTransferObjects.Responses.Contract;
-using EstateManagement.DataTransferObjects.Responses.Estate;
-using EstateManagement.DataTransferObjects.Responses.Merchant;
-using EstateManagement.DataTransferObjects.Responses.Operator;
-using EstateManagementUI.BusinessLogic.Common;
+﻿using EstateManagementUI.BusinessLogic.Common;
 using EstateManagementUI.BusinessLogic.Models;
 using EstateReportingAPI.Client;
 using EstateReportingAPI.DataTransferObjects;
@@ -15,18 +7,26 @@ using FileProcessor.Client;
 using FileProcessor.DataTransferObjects.Responses;
 using Shared.Logger;
 using SimpleResults;
+using TransactionProcessor.Client;
+using TransactionProcessor.DataTransferObjects.Requests.Contract;
+using TransactionProcessor.DataTransferObjects.Requests.Merchant;
+using TransactionProcessor.DataTransferObjects.Requests.Operator;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
+using TransactionProcessor.DataTransferObjects.Responses.Estate;
+using TransactionProcessor.DataTransferObjects.Responses.Merchant;
+using TransactionProcessor.DataTransferObjects.Responses.Operator;
 
 namespace EstateManagementUI.BusinessLogic.Clients;
 
 public class ApiClient : IApiClient {
-    private readonly IEstateClient EstateClient;
+    private readonly ITransactionProcessorClient TransactionProcessorClient;
     private readonly IFileProcessorClient FileProcessorClient;
     private readonly IEstateReportingApiClient EstateReportingApiClient;
 
-    public ApiClient(IEstateClient estateClient,
+    public ApiClient(ITransactionProcessorClient transactionProcessorClient,
                      IFileProcessorClient fileProcessorClient,
                      IEstateReportingApiClient estateReportingApiClient) {
-        this.EstateClient = estateClient;
+        this.TransactionProcessorClient = transactionProcessorClient;
         this.FileProcessorClient = fileProcessorClient;
         this.EstateReportingApiClient = estateReportingApiClient;
     }
@@ -40,7 +40,7 @@ public class ApiClient : IApiClient {
         async Task<Result> ClientMethod() {
             AssignOperatorRequest apiRequest = ModelFactory.ConvertFrom(assignOperatorToMerchantModel);
 
-            return await this.EstateClient.AssignOperatorToMerchant(accessToken, estateId, merchantId, apiRequest, cancellationToken);
+            return await this.TransactionProcessorClient.AssignOperatorToMerchant(accessToken, estateId, merchantId, apiRequest, cancellationToken);
         }
 
         ;
@@ -57,7 +57,7 @@ public class ApiClient : IApiClient {
         async Task<Result> ClientMethod() {
             AddMerchantContractRequest apiRequest = ModelFactory.ConvertFrom(assignContractToMerchantModel);
 
-            return await this.EstateClient.AddContractToMerchant(accessToken, estateId, merchantId, apiRequest, cancellationToken);
+            return await this.TransactionProcessorClient.AddContractToMerchant(accessToken, estateId, merchantId, apiRequest, cancellationToken);
         }
 
         ;
@@ -72,7 +72,7 @@ public class ApiClient : IApiClient {
                                                          Guid operatorId,
                                                          CancellationToken cancellationToken) {
         async Task<Result> ClientMethod() {
-            return await this.EstateClient.RemoveOperatorFromMerchant(accessToken, estateId, merchantId, operatorId, cancellationToken);
+            return await this.TransactionProcessorClient.RemoveOperatorFromMerchant(accessToken, estateId, merchantId, operatorId, cancellationToken);
         }
 
         ;
@@ -87,7 +87,7 @@ public class ApiClient : IApiClient {
                                                          Guid contractId,
                                                          CancellationToken cancellationToken) {
         async Task<Result> ClientMethod() {
-            return await this.EstateClient.RemoveContractFromMerchant(accessToken, estateId, merchantId, contractId, cancellationToken);
+            return await this.TransactionProcessorClient.RemoveContractFromMerchant(accessToken, estateId, merchantId, contractId, cancellationToken);
         }
 
         ;
@@ -117,7 +117,7 @@ public class ApiClient : IApiClient {
                                              Guid estateId,
                                              CancellationToken cancellationToken) {
         async Task<Result<EstateModel>> ClientMethod() {
-            Result<EstateResponse>? result = await this.EstateClient.GetEstate(accessToken, estateId, cancellationToken);
+            Result<EstateResponse>? result = await this.TransactionProcessorClient.GetEstate(accessToken, estateId, cancellationToken);
             if (result.IsFailed)
                 return ResultHelpers.CreateFailure(result);
             return ModelFactory.ConvertFrom(result.Data);
@@ -131,7 +131,7 @@ public class ApiClient : IApiClient {
                                                                 Guid estateId,
                                                                 CancellationToken cancellationToken) {
         async Task<Result<List<MerchantModel>>> ClientMethod() {
-            Result<List<MerchantResponse>>? result = await this.EstateClient.GetMerchants(accessToken, estateId, cancellationToken);
+            Result<List<MerchantResponse>>? result = await this.TransactionProcessorClient.GetMerchants(accessToken, estateId, cancellationToken);
             if (result.IsFailed)
                 return ResultHelpers.CreateFailure(result);
             return ModelFactory.ConvertFrom(result.Data);
@@ -146,7 +146,7 @@ public class ApiClient : IApiClient {
                                                          Guid merchantId,
                                                          CancellationToken cancellationToken) {
         async Task<Result<MerchantModel>> ClientMethod() {
-            Result<MerchantResponse>? result = await this.EstateClient.GetMerchant(accessToken, estateId, merchantId, cancellationToken);
+            Result<MerchantResponse>? result = await this.TransactionProcessorClient.GetMerchant(accessToken, estateId, merchantId, cancellationToken);
             if (result.IsFailed)
                 return ResultHelpers.CreateFailure(result);
             return ModelFactory.ConvertFrom(result.Data);
@@ -160,7 +160,7 @@ public class ApiClient : IApiClient {
                                                                 Guid estateId,
                                                                 CancellationToken cancellationToken) {
         async Task<Result<List<OperatorModel>>> ClientMethod() {
-            Result<List<OperatorResponse>>? result = await this.EstateClient.GetOperators(accessToken, estateId, cancellationToken);
+            Result<List<OperatorResponse>>? result = await this.TransactionProcessorClient.GetOperators(accessToken, estateId, cancellationToken);
             if (result.IsFailed)
                 return ResultHelpers.CreateFailure(result);
             return ModelFactory.ConvertFrom(result.Data);
@@ -175,7 +175,7 @@ public class ApiClient : IApiClient {
                                                          Guid operatorId,
                                                          CancellationToken cancellationToken) {
         async Task<Result<OperatorModel>> ClientMethod() {
-            Result<OperatorResponse>? result = await this.EstateClient.GetOperator(accessToken, estateId, operatorId, cancellationToken);
+            Result<OperatorResponse>? result = await this.TransactionProcessorClient.GetOperator(accessToken, estateId, operatorId, cancellationToken);
             if (result.IsFailed)
                 return ResultHelpers.CreateFailure(result);
             return ModelFactory.ConvertFrom(result.Data);
@@ -189,7 +189,7 @@ public class ApiClient : IApiClient {
                                                                 Guid estateId,
                                                                 CancellationToken cancellationToken) {
         async Task<Result<List<ContractModel>>> ClientMethod() {
-            Result<List<ContractResponse>>? result = await this.EstateClient.GetContracts(accessToken, estateId, cancellationToken);
+            Result<List<ContractResponse>>? result = await this.TransactionProcessorClient.GetContracts(accessToken, estateId, cancellationToken);
             if (result.IsFailed)
                 return ResultHelpers.CreateFailure(result);
             return ModelFactory.ConvertFrom(result.Data);
@@ -204,7 +204,7 @@ public class ApiClient : IApiClient {
                                                          Guid contractId,
                                                          CancellationToken cancellationToken) {
         async Task<Result<ContractModel>> ClientMethod() {
-            Result<ContractResponse>? result = await this.EstateClient.GetContract(accessToken, estateId, contractId, cancellationToken);
+            Result<ContractResponse>? result = await this.TransactionProcessorClient.GetContract(accessToken, estateId, contractId, cancellationToken);
             if (result.IsFailed)
                 return ResultHelpers.CreateFailure(result);
             return ModelFactory.ConvertFrom(result.Data);
@@ -221,7 +221,7 @@ public class ApiClient : IApiClient {
         async Task<Result> ClientMethod() {
             CreateOperatorRequest request = new() { RequireCustomMerchantNumber = createOperatorModel.RequireCustomMerchantNumber, RequireCustomTerminalNumber = createOperatorModel.RequireCustomTerminalNumber, Name = createOperatorModel.OperatorName, OperatorId = createOperatorModel.OperatorId };
 
-            return await this.EstateClient.CreateOperator(accessToken, estateId, request, cancellationToken);
+            return await this.TransactionProcessorClient.CreateOperator(accessToken, estateId, request, cancellationToken);
         }
 
         return await this.CallClientMethod(ClientMethod, cancellationToken);
@@ -235,7 +235,7 @@ public class ApiClient : IApiClient {
         async Task<Result> ClientMethod() {
             UpdateOperatorRequest request = new() { RequireCustomMerchantNumber = updateOperatorModel.RequireCustomMerchantNumber, RequireCustomTerminalNumber = updateOperatorModel.RequireCustomTerminalNumber, Name = updateOperatorModel.OperatorName };
 
-            return await this.EstateClient.UpdateOperator(accessToken, estateId, updateOperatorModel.OperatorId, request, cancellationToken);
+            return await this.TransactionProcessorClient.UpdateOperator(accessToken, estateId, updateOperatorModel.OperatorId, request, cancellationToken);
         }
 
         return await this.CallClientMethod(ClientMethod, cancellationToken);
@@ -471,7 +471,7 @@ public class ApiClient : IApiClient {
         async Task<Result> ClientMethod()
         {
             CreateContractRequest apiRequest = ModelFactory.ConvertFrom(createContractModel);
-            return await this.EstateClient.CreateContract(accessToken, estateId, apiRequest, cancellationToken);
+            return await this.TransactionProcessorClient.CreateContract(accessToken, estateId, apiRequest, cancellationToken);
         }
         return await this.CallClientMethod(ClientMethod, cancellationToken);
     }
@@ -483,7 +483,7 @@ public class ApiClient : IApiClient {
         async Task<Result> ClientMethod() {
             CreateMerchantRequest apiRequest = ModelFactory.ConvertFrom(createMerchantModel);
 
-            return await this.EstateClient.CreateMerchant(accessToken, estateId, apiRequest, cancellationToken);
+            return await this.TransactionProcessorClient.CreateMerchant(accessToken, estateId, apiRequest, cancellationToken);
         }
 
         return await this.CallClientMethod(ClientMethod, cancellationToken);
@@ -498,7 +498,7 @@ public class ApiClient : IApiClient {
         async Task<Result> ClientMethod() {
             UpdateMerchantRequest apiRequest = ModelFactory.ConvertFrom(updateMerchantModel);
 
-            return await this.EstateClient.UpdateMerchant(accessToken, estateId, merchantId, apiRequest, cancellationToken);
+            return await this.TransactionProcessorClient.UpdateMerchant(accessToken, estateId, merchantId, apiRequest, cancellationToken);
         }
 
         return await this.CallClientMethod(ClientMethod, cancellationToken);
@@ -513,7 +513,7 @@ public class ApiClient : IApiClient {
         async Task<Result> ClientMethod() {
             Address apiRequest = ModelFactory.ConvertFrom(updateAddressModel);
 
-            return await this.EstateClient.UpdateMerchantAddress(accessToken, estateId, merchantId, updateAddressModel.AddressId, apiRequest, cancellationToken);
+            return await this.TransactionProcessorClient.UpdateMerchantAddress(accessToken, estateId, merchantId, updateAddressModel.AddressId, apiRequest, cancellationToken);
         }
 
         return await this.CallClientMethod(ClientMethod, cancellationToken);
@@ -528,7 +528,7 @@ public class ApiClient : IApiClient {
         async Task<Result> ClientMethod() {
             Contact apiRequest = ModelFactory.ConvertFrom(updateContactModel);
 
-            return await this.EstateClient.UpdateMerchantContact(accessToken, estateId, merchantId, updateContactModel.ContactId, apiRequest, cancellationToken);
+            return await this.TransactionProcessorClient.UpdateMerchantContact(accessToken, estateId, merchantId, updateContactModel.ContactId, apiRequest, cancellationToken);
         }
 
         return await this.CallClientMethod(ClientMethod, cancellationToken);

--- a/EstateManagementUI.BusinessLogic/Common/ModelFactory.cs
+++ b/EstateManagementUI.BusinessLogic/Common/ModelFactory.cs
@@ -1,19 +1,19 @@
 ﻿using System.Runtime.CompilerServices;
 using Azure;
-using EstateManagement.DataTransferObjects.Requests.Contract;
-using EstateManagement.DataTransferObjects.Requests.Merchant;
-using EstateManagement.DataTransferObjects.Responses.Contract;
-using EstateManagement.DataTransferObjects.Responses.Estate;
-using EstateManagement.DataTransferObjects.Responses.Merchant;
-using EstateManagement.DataTransferObjects.Responses.Operator;
 using EstateManagementUI.BusinessLogic.Models;
 using EstateManagmentUI.BusinessLogic.Requests;
 using EstateReportingAPI.DataTransferObjects;
 using EstateReportingAPI.DataTrasferObjects;
 using FileProcessor.DataTransferObjects.Responses;
 using SimpleResults;
+using TransactionProcessor.DataTransferObjects.Requests.Contract;
+using TransactionProcessor.DataTransferObjects.Requests.Merchant;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
+using TransactionProcessor.DataTransferObjects.Responses.Estate;
+using TransactionProcessor.DataTransferObjects.Responses.Merchant;
+using TransactionProcessor.DataTransferObjects.Responses.Operator;
 using FileLineProcessingResult = FileProcessor.DataTransferObjects.Responses.FileLineProcessingResult;
-using SettlementSchedule = EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule;
+using SettlementSchedule = TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule;
 
 namespace EstateManagementUI.BusinessLogic.Common;
 

--- a/EstateManagementUI.BusinessLogic/EstateManagementUI.BusinessLogic.csproj
+++ b/EstateManagementUI.BusinessLogic/EstateManagementUI.BusinessLogic.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EstateManagement.Client" Version="2024.8.2-build128" />
     <PackageReference Include="FileProcessor.Client" Version="2024.8.2-build69" />
     <PackageReference Include="MediatR" Version="12.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.7" />
@@ -19,6 +18,7 @@
     <PackageReference Include="SimpleResults" Version="3.0.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageReference Include="EstateReportingAPI.Client" Version="2024.7.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2025.1.5-build147" />
   </ItemGroup>
 
 </Project>

--- a/EstateManagementUI.BusinessLogic/Models/MerchantModel.cs
+++ b/EstateManagementUI.BusinessLogic/Models/MerchantModel.cs
@@ -1,7 +1,5 @@
-﻿using EstateManagement.DataTransferObjects.Responses.Contract;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System.Diagnostics.CodeAnalysis;
-using EstateManagement.DataTransferObjects.Requests.Merchant;
 
 namespace EstateManagementUI.BusinessLogic.Models;
 

--- a/EstateManagementUI.BusinessLogic/Models/UpdateOperatorModel.cs
+++ b/EstateManagementUI.BusinessLogic/Models/UpdateOperatorModel.cs
@@ -1,5 +1,4 @@
-﻿using EstateManagement.DataTransferObjects.Responses.Merchant;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EstateManagementUI.BusinessLogic.Models;

--- a/EstateManagementUI.BusinessLogic/RequestHandlers/ContractRequestHandler.cs
+++ b/EstateManagementUI.BusinessLogic/RequestHandlers/ContractRequestHandler.cs
@@ -1,5 +1,4 @@
-﻿using EstateManagement.DataTransferObjects.Requests.Operator;
-using EstateManagementUI.BusinessLogic.Clients;
+﻿using EstateManagementUI.BusinessLogic.Clients;
 using EstateManagementUI.BusinessLogic.Models;
 using EstateManagmentUI.BusinessLogic.Requests;
 using MediatR;

--- a/EstateManagementUI.BusinessLogic/Requests/Commands.cs
+++ b/EstateManagementUI.BusinessLogic/Requests/Commands.cs
@@ -1,7 +1,6 @@
 ﻿using MediatR;
 using SimpleResults;
 using System.Diagnostics.CodeAnalysis;
-using EstateManagement.DataTransferObjects.Requests.Merchant;
 using EstateManagementUI.BusinessLogic.Models;
 
 namespace EstateManagmentUI.BusinessLogic.Requests;

--- a/EstateManagementUI.IntegrationTests/Common/ClientDetails.cs
+++ b/EstateManagementUI.IntegrationTests/Common/ClientDetails.cs
@@ -1,4 +1,7 @@
-﻿namespace EstateManagementUI.IntegrationTests.Common
+﻿using System;
+using System.Collections.Generic;
+
+namespace EstateManagementUI.IntegrationTests.Common
 {
     public class ClientDetails
     {

--- a/EstateManagementUI.IntegrationTests/Common/DockerHelper.cs
+++ b/EstateManagementUI.IntegrationTests/Common/DockerHelper.cs
@@ -133,6 +133,19 @@ namespace EstateManagementUI.IntegrationTests.Common
             }
         }
 
+        protected override List<String> GetRequiredProjections()
+        {
+            List<String> requiredProjections = new List<String>();
+
+            requiredProjections.Add("CallbackHandlerEnricher.js");
+            requiredProjections.Add("EstateAggregator.js");
+            requiredProjections.Add("MerchantAggregator.js");
+            requiredProjections.Add("MerchantBalanceCalculator.js");
+            requiredProjections.Add("MerchantBalanceProjection.js");
+
+            return requiredProjections;
+        }
+
         /// <summary>
         /// Starts the containers for scenario run.
         /// </summary>

--- a/EstateManagementUI.IntegrationTests/Common/EstateManagementUiSteps.cs
+++ b/EstateManagementUI.IntegrationTests/Common/EstateManagementUiSteps.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using EstateManagementUI.IntegrationTests.Steps;
 using EventStore.Client;
 using OpenQA.Selenium;

--- a/EstateManagementUI.IntegrationTests/Common/Extensions.cs
+++ b/EstateManagementUI.IntegrationTests/Common/Extensions.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using Shared.IntegrationTesting;

--- a/EstateManagementUI.IntegrationTests/Common/GenericSteps.cs
+++ b/EstateManagementUI.IntegrationTests/Common/GenericSteps.cs
@@ -1,4 +1,6 @@
-﻿using NLog;
+﻿using System;
+using System.Threading.Tasks;
+using NLog;
 using Reqnroll;
 using Shared.IntegrationTesting;
 using Shared.Logger;
@@ -29,7 +31,7 @@ namespace EstateManagementUI.IntegrationTests.Common
             logger.Initialise(LogManager.GetLogger(scenarioName), scenarioName);
             LogManager.AddHiddenAssembly(typeof(NlogLogger).Assembly);
 
-            DockerServices dockerServices = DockerServices.CallbackHandler | DockerServices.EstateManagement | DockerServices.EventStore |
+            DockerServices dockerServices = DockerServices.CallbackHandler | DockerServices.EventStore |
                                             DockerServices.FileProcessor | DockerServices.MessagingService | DockerServices.SecurityService |
                                             DockerServices.TestHost | DockerServices.SqlServer | DockerServices.TransactionProcessor |
                                             DockerServices.TransactionProcessorAcl;

--- a/EstateManagementUI.IntegrationTests/Common/Setup.cs
+++ b/EstateManagementUI.IntegrationTests/Common/Setup.cs
@@ -1,4 +1,5 @@
-﻿using Ductus.FluentDocker.Services;
+﻿using System;
+using Ductus.FluentDocker.Services;
 using Ductus.FluentDocker.Services.Extensions;
 using Reqnroll;
 using Shouldly;

--- a/EstateManagementUI.IntegrationTests/Common/TestingContext.cs
+++ b/EstateManagementUI.IntegrationTests/Common/TestingContext.cs
@@ -1,9 +1,12 @@
-﻿using EstateManagement.IntegrationTesting.Helpers;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Reqnroll;
 using SecurityService.DataTransferObjects.Responses;
-using Shared.IntegrationTesting;
 using Shared.Logger;
 using Shouldly;
+using TransactionProcessor.IntegrationTesting.Helpers;
+using ReqnrollTableHelper = Shared.IntegrationTesting.ReqnrollTableHelper;
 
 namespace EstateManagementUI.IntegrationTests.Common
 {

--- a/EstateManagementUI.IntegrationTests/EstateManagementUI.IntegrationTests.csproj
+++ b/EstateManagementUI.IntegrationTests/EstateManagementUI.IntegrationTests.csproj
@@ -26,8 +26,6 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="EstateManagement.Client" Version="2024.8.2-build128" />
-	  <PackageReference Include="EstateManagement.Database" Version="2024.8.2-build128" />
 	  <PackageReference Include="SecurityService.Client" Version="2024.88.2-build73" />
 	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2024.88.2-build73" />
 	  <PackageReference Include="Shouldly" Version="4.2.1" />
@@ -37,15 +35,17 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Reqnroll" Version="2.0.3" />
     <PackageReference Include="Reqnroll.NUnit" Version="2.0.3" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2024.11.4" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2025.1.2" />
 	  <PackageReference Include="Selenium.Support" Version="4.23.0" />
 	  <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
 
 	  <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2024.8.2-build65" />
 
-	  <PackageReference Include="EstateManagement.IntegrationTesting.Helpers" Version="2024.8.2-build128" />
+	  <PackageReference Include="TransactionProcessor.Client" Version="2025.1.5-build147" />
 
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2024.8.2-build119" />
+	  <PackageReference Include="TransactionProcessor.Database" Version="2025.1.5-build147" />
+
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.1.5-build147" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EstateManagementUI.IntegrationTests/EstateManagementUI.IntegrationTests.csproj
+++ b/EstateManagementUI.IntegrationTests/EstateManagementUI.IntegrationTests.csproj
@@ -26,6 +26,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
+	  <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
 	  <PackageReference Include="SecurityService.Client" Version="2024.88.2-build73" />
 	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2024.88.2-build73" />
 	  <PackageReference Include="Shouldly" Version="4.2.1" />

--- a/EstateManagementUI.IntegrationTests/Steps/Gimp.cs
+++ b/EstateManagementUI.IntegrationTests/Steps/Gimp.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Shared.IntegrationTesting;
-using EstateManagement.IntegrationTesting.Helpers;
 using EstateManagementUI.IntegrationTests.Common;
 using OpenQA.Selenium;
 using Reqnroll.BoDi;

--- a/EstateManagementUI.Testing/TestData.cs
+++ b/EstateManagementUI.Testing/TestData.cs
@@ -1,7 +1,3 @@
-using EstateManagement.DataTransferObjects.Responses.Contract;
-using EstateManagement.DataTransferObjects.Responses.Estate;
-using EstateManagement.DataTransferObjects.Responses.Merchant;
-using EstateManagement.DataTransferObjects.Responses.Operator;
 using EstateManagementUI.BusinessLogic.Models;
 using EstateManagementUI.ViewModels;
 using EstateManagmentUI.BusinessLogic.Requests;
@@ -10,14 +6,16 @@ using EstateReportingAPI.DataTrasferObjects;
 using FileProcessor.DataTransferObjects.Responses;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using SimpleResults;
-using ContractProduct = EstateManagement.DataTransferObjects.Responses.Contract.ContractProduct;
-using ContractProductTransactionFee = EstateManagement.DataTransferObjects.Responses.Contract.ContractProductTransactionFee;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
+using TransactionProcessor.DataTransferObjects.Responses.Estate;
+using TransactionProcessor.DataTransferObjects.Responses.Merchant;
+using TransactionProcessor.DataTransferObjects.Responses.Operator;
 using FileImportLogList = FileProcessor.DataTransferObjects.Responses.FileImportLogList;
 using FileLine = FileProcessor.DataTransferObjects.Responses.FileLine;
 using FileLineProcessingResult = FileProcessor.DataTransferObjects.Responses.FileLineProcessingResult;
 using LastSettlement = EstateReportingAPI.DataTransferObjects.LastSettlement;
 using MerchantKpi = EstateReportingAPI.DataTransferObjects.MerchantKpi;
-using SettlementSchedule = EstateManagement.DataTransferObjects.Responses.Merchant.SettlementSchedule;
+using SettlementSchedule = EstateManagementUI.BusinessLogic.Models.SettlementSchedule;
 using TodaysSales = EstateReportingAPI.DataTransferObjects.TodaysSales;
 using TodaysSalesCountByHour = EstateReportingAPI.DataTransferObjects.TodaysSalesCountByHour;
 using TodaysSalesCountByHourModel = EstateManagementUI.BusinessLogic.Models.TodaysSalesCountByHourModel;
@@ -190,7 +188,7 @@ namespace EstateManagementUI.Testing
         public static String Merchant1Reference = "Reference1";
         public static String Merchant1Name = "Test Merchant 1";
         public static Guid Merchant1Id = Guid.Parse("2F8431D9-8D04-4AE5-B66C-DB40DFADE581");
-        public static SettlementSchedule Merchant1SettlementSchedule = SettlementSchedule.Immediate;
+        public static TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule Merchant1SettlementSchedule = TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Immediate;
 
         public static String Merchant1AddressLine1 = "Address Line 1";
 
@@ -237,7 +235,7 @@ namespace EstateManagementUI.Testing
         public static String Merchant2Reference = "Reference2";
         public static String Merchant2Name = "Test Merchant 2";
         public static Guid Merchant2Id = Guid.Parse("8959608C-2448-48EA-AFB4-9D10FFFB6140");
-        public static SettlementSchedule Merchant2SettlementSchedule = SettlementSchedule.Weekly;
+        public static TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule Merchant2SettlementSchedule = TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Weekly;
 
         public static AddressResponse
             Merchant2Address = new() { AddressLine1 = "Address Line 2", Town = "Test Town 2" };
@@ -247,7 +245,7 @@ namespace EstateManagementUI.Testing
         public static String Merchant3Reference = "Reference3";
         public static String Merchant3Name = "Test Merchant 3";
         public static Guid Merchant3Id = Guid.Parse("877D7384-9A72-4A73-A275-9DB62BF32EDB");
-        public static SettlementSchedule Merchant3SettlementSchedule = SettlementSchedule.Monthly;
+        public static TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule Merchant3SettlementSchedule = TransactionProcessor.DataTransferObjects.Responses.Merchant.SettlementSchedule.Monthly;
 
         public static AddressResponse
             Merchant3Address = new() { AddressLine1 = "Address Line 3", Town = "Test Town 3" };
@@ -375,8 +373,8 @@ namespace EstateManagementUI.Testing
         public static CalculationType TransactionFee1CalculationType = CalculationType.Fixed;
         public static Guid TransactionFee1Id = Guid.Parse("61D0AF6D-1303-459F-87E2-4B686BB0585E");
 
-        public static ContractProductTransactionFee ContractProductTransactionFee1 =>
-            new ContractProductTransactionFee {
+        public static TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProductTransactionFee ContractProductTransactionFee1 =>
+            new TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProductTransactionFee {
                 Value = TransactionFee1Value,
                 Description = TransactionFee1Description,
                 FeeType = TransactionFee1Type,
@@ -384,20 +382,20 @@ namespace EstateManagementUI.Testing
                 TransactionFeeId = TransactionFee1Id,
             };
 
-        public static ContractProduct ContractProduct1 =>
-            new ContractProduct {
+        public static TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProduct ContractProduct1 =>
+            new TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProduct {
                 Name = Contract1Product1Name,
                 DisplayText = Contract1Product1DisplayText,
                 ProductId = Contract1Product1Id,
                 ProductType = Contract1Product1ProductType,
                 Value = Contract1Product1Value,
-                TransactionFees = new List<ContractProductTransactionFee> {
+                TransactionFees = new List<TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProductTransactionFee> {
                     ContractProductTransactionFee1
                 }
             };
 
-        public static ContractProduct ContractProduct2 =>
-            new ContractProduct
+        public static TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProduct ContractProduct2 =>
+            new TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProduct
             {
                 Name = Contract1Product2Name,
                 DisplayText = Contract1Product2DisplayText,
@@ -406,8 +404,8 @@ namespace EstateManagementUI.Testing
                 Value = Contract1Product2Value
             };
 
-        public static ContractProduct ContractProduct3 =>
-            new ContractProduct
+        public static TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProduct ContractProduct3 =>
+            new TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProduct
             {
                 Name = Contract1Product3Name,
                 DisplayText = Contract1Product3DisplayText,
@@ -423,7 +421,7 @@ namespace EstateManagementUI.Testing
                 OperatorName = Operator1Name,
                 ContractId = Contract1Id,
                 Description = Contract1Description,
-                Products = new List<ContractProduct> { ContractProduct1, ContractProduct2, ContractProduct3 }
+                Products = new List<TransactionProcessor.DataTransferObjects.Responses.Contract.ContractProduct> { ContractProduct1, ContractProduct2, ContractProduct3 }
             };
 
         public static List<ContractResponse> ContractResponses =>

--- a/EstateManagementUI/Bootstrapper/ClientRegistry.cs
+++ b/EstateManagementUI/Bootstrapper/ClientRegistry.cs
@@ -1,11 +1,11 @@
-﻿using EstateManagement.Client;
-using EstateManagementUI.BusinessLogic.Clients;
+﻿using EstateManagementUI.BusinessLogic.Clients;
 using Lamar;
 using Shared.General;
 using System.Net.Http;
 using FileProcessor.Client;
 using System.Diagnostics.CodeAnalysis;
 using EstateReportingAPI.Client;
+using TransactionProcessor.Client;
 
 namespace EstateManagementUI.Bootstrapper;
 
@@ -17,6 +17,7 @@ public class ClientRegistry : ServiceRegistry
         //this.AddSingleton<IConfigurationService, ConfigurationService>();
         this.AddSingleton<IApiClient, ApiClient>();
         this.AddSingleton<IFileProcessorClient, FileProcessorClient>();
+        this.AddSingleton<ITransactionProcessorClient, TransactionProcessorClient>();
         this.AddSingleton<IEstateReportingApiClient, EstateReportingApiClient>();
         this.AddSingleton<Func<String, String>>(container => (serviceName) =>
         {
@@ -36,7 +37,6 @@ public class ClientRegistry : ServiceRegistry
         }
         this.AddSingleton(httpClient);
         
-        Func<String, String> resolver1() => serviceName => { return ConfigurationReader.GetBaseServerUri(serviceName).OriginalString; };
-        this.AddSingleton<IEstateClient>(new EstateClient(resolver1(), httpClient, 2));
+        
     }
 }

--- a/EstateManagementUI/Pages/Merchant/MerchantDetails/AddContractDialog.cshtml.cs
+++ b/EstateManagementUI/Pages/Merchant/MerchantDetails/AddContractDialog.cshtml.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using EstateManagement.DataTransferObjects.Requests.Merchant;
 using EstateManagementUI.Pages.Shared.Components;
 using EstateManagmentUI.BusinessLogic.Requests;
 using Hydro;

--- a/EstateManagementUI/Pages/Merchant/MerchantDetails/AddOperatorDialog.cshtml.cs
+++ b/EstateManagementUI/Pages/Merchant/MerchantDetails/AddOperatorDialog.cshtml.cs
@@ -6,7 +6,6 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.ComponentModel.DataAnnotations;
-using EstateManagement.DataTransferObjects.Requests.Merchant;
 using EstateManagementUI.Pages.Shared.Components;
 using EstateManagmentUI.BusinessLogic.Requests;
 using Hydro;


### PR DESCRIPTION
This commit replaces all instances of `EstateManagement.Client` with `TransactionProcessor.Client` across the codebase. Key changes include:
- Updated `ApiClientTests.cs` to utilize `ITransactionProcessorClient` and modified test setups accordingly.
- Refactored `ModelFactoryTests.cs` to align with new data transfer objects from `TransactionProcessor`.
- Significant modifications in `ApiClient.cs` to replace `EstateClient` references with `TransactionProcessorClient`, affecting methods for managing estates, merchants, operators, and contracts.
- Adjusted `ModelFactory.cs` to ensure proper conversion between business logic models and the new API models.
- Updated project dependencies in `EstateManagementUI.BusinessLogic.csproj` to include `TransactionProcessor.Client`.
- Ensured all tests and integration tests reflect the new client architecture and data structures.

This migration enhances the service architecture for handling API requests related to merchants, operators, and contracts.