### PR TITLE
Update permissions handling and add unit tests

### DIFF
--- a/EstateManagementUI.BusinessLogic.Tests/EstateManagementUI.BusinessLogic.Tests.csproj
+++ b/EstateManagementUI.BusinessLogic.Tests/EstateManagementUI.BusinessLogic.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<DebugType>Full</DebugType>
+	<DebugType>None</DebugType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/EstateManagementUI.BusinessLogic.Tests/PermissionsServiceTests.cs
+++ b/EstateManagementUI.BusinessLogic.Tests/PermissionsServiceTests.cs
@@ -1,0 +1,252 @@
+﻿using EstateManagementUI.BusinessLogic.PermissionService;
+using EstateManagementUI.Testing;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Shared.General;
+using Shouldly;
+using SimpleResults;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EstateManagementUI.BusinessLogic.Common;
+using Xunit;
+
+namespace EstateManagementUI.BusinessLogic.Tests
+{
+    public class PermissionsServiceTests
+    {
+        private readonly Mock<IPermissionsRepository> _permissionsRepositoryMock;
+        private readonly Mock<IConfigurationService> _configurationServiceMock;
+        private readonly PermissionsService _permissionsService;
+        
+        public PermissionsServiceTests()
+        {
+            _permissionsRepositoryMock = new Mock<IPermissionsRepository>();
+            _configurationServiceMock = new Mock<IConfigurationService>();
+            _permissionsService = new PermissionsService(_permissionsRepositoryMock.Object, this._configurationServiceMock.Object);
+            
+        }
+        
+        [Fact]
+        public async Task DoIHavePermissions_BypassPermissions_ReturnsSuccess()
+        {
+            // Arrange
+            this._configurationServiceMock.Setup(service => service.GetPermissionsBypass()).Returns(true);
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section", "function");
+
+            // Assert
+            Assert.True(result.IsSuccess);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task DoIHavePermissions_UserNameValidation_ReturnsForbidden(String userName)
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>());
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)>());
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions(userName, "section", "function");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task DoIHavePermissions_SectionNameValidation_ReturnsForbidden(String sectionName)
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>());
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)>());
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", sectionName, "function");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task DoIHavePermissions_FunctionValidation_ReturnsForbidden(String function)
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>());
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)>());
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section", function);
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public async Task DoIHavePermissions_NoRolesAssigned_ReturnsForbidden()
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>());
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)>());
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section", "function");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public async Task DoIHavePermissions_NoFunctionsAssigned_ReturnsForbidden()
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>());
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)> { ("user", "role") });
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section", "function");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public async Task DoIHavePermissions_NoPermissions_ReturnsSuccess()
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)> { ("role", "section", "function") });
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)> { ("user", "role") });
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section", "function1");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public async Task DoIHavePermissions_PermissionGranted_ReturnsSuccess()
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)> { ("role", "section", "function") });
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)> { ("user", "role") });
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section", "function");
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task DoIHavePermissions_SectionOnly_BypassPermissions_ReturnsSuccess()
+        {
+            // Arrange
+            this._configurationServiceMock.Setup(service => service.GetPermissionsBypass()).Returns(true);
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section");
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task DoIHavePermissions_SectionOnly_UserNameValidation_ReturnsForbidden(String userName)
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>());
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)>());
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions(userName, "section");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task DoIHavePermissions_SectionOnly_SectionNameValidation_ReturnsForbidden(String sectionName)
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>());
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)>());
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", sectionName);
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public async Task DoIHavePermissions_SectionOnly_NoRolesAssigned_ReturnsForbidden()
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>());
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)>());
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public async Task DoIHavePermissions_SectionOnly_NoFunctionsAssigned_ReturnsForbidden()
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>());
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)> { ("user", "role") });
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public async Task DoIHavePermissions_SectionOnly_NoPermission_ReturnsForbidden()
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)>() {
+                ("role", "section1", "function")
+            });
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)> { ("user", "role") });
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public async Task DoIHavePermissions_SectionOnly_PermissionGranted_ReturnsSuccess()
+        {
+            // Arrange
+            _permissionsRepositoryMock.Setup(repo => repo.GetRolesFunctions()).ReturnsAsync(new List<(string, string, string)> { ("role", "section", "function") });
+            _permissionsRepositoryMock.Setup(repo => repo.GetUsers(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(string, string)> { ("user", "role") });
+
+            // Act
+            var result = await _permissionsService.DoIHavePermissions("user", "section");
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+    }
+}

--- a/EstateManagementUI.BusinessLogic/Common/ConfigurationService.cs
+++ b/EstateManagementUI.BusinessLogic/Common/ConfigurationService.cs
@@ -1,0 +1,11 @@
+﻿using Shared.General;
+
+namespace EstateManagementUI.BusinessLogic.Common;
+
+public class ConfigurationService : IConfigurationService
+{
+    public Boolean GetPermissionsBypass()
+    {
+        return ConfigurationReader.GetValueOrDefault<Boolean>("AppSettings", "PermissionsBypass", false);
+    }
+}

--- a/EstateManagementUI.BusinessLogic/Common/IConfigurationService.cs
+++ b/EstateManagementUI.BusinessLogic/Common/IConfigurationService.cs
@@ -1,0 +1,6 @@
+﻿namespace EstateManagementUI.BusinessLogic.Common;
+
+public interface IConfigurationService
+{
+    Boolean GetPermissionsBypass();
+}

--- a/EstateManagementUI.BusinessLogic/PermissionService/IPermissionsService.cs
+++ b/EstateManagementUI.BusinessLogic/PermissionService/IPermissionsService.cs
@@ -9,8 +9,5 @@ namespace EstateManagementUI.BusinessLogic.PermissionService
 
         Task<Result> DoIHavePermissions(String userName,
                                         String sectionName);
-
-        Task<Result> LoadPermissionsData();
-
     }
 }

--- a/EstateManagementUI.UITests/EstateManagementUI.UITests.csproj
+++ b/EstateManagementUI.UITests/EstateManagementUI.UITests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <DebugType>Full</DebugType>
+	  <DebugType>None</DebugType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/EstateManagementUI/Bootstrapper/AuthenticationRegistry.cs
+++ b/EstateManagementUI/Bootstrapper/AuthenticationRegistry.cs
@@ -3,6 +3,7 @@ using System.Net.Mime;
 using System.Reflection;
 using EstateAdministrationUI.TokenManagement;
 using EstateManagementUI.BusinessLogic.Clients;
+using EstateManagementUI.BusinessLogic.Common;
 using EstateManagementUI.BusinessLogic.PermissionService;
 using EstateManagementUI.BusinessLogic.PermissionService.Database;
 using EstateManagementUI.Common;
@@ -104,6 +105,7 @@ public class AuthenticationRegistry : ServiceRegistry {
         });
             
         this.AddAuthorization();
+        this.AddSingleton<IConfigurationService, ConfigurationService>();
         this.AddSingleton<IPermissionsService, PermissionsService>();
         this.AddSingleton<IPermissionsRepository, PermissionsRepository>();
         String dbFileName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "permissions.db");


### PR DESCRIPTION
- Changed target framework settings for test projects.
- Removed `LoadPermissionsData()` from `IPermissionsService`.
- Updated `PermissionsService` to use `ConfigurationService` for permissions bypass logic.
- Made `LoadPermissionsData()` private and adjusted its return type.
- Added `ConfigurationService` class implementing `IConfigurationService`.
- Created `PermissionsServiceTests` with comprehensive unit tests for permission checks.
- Updated `AuthenticationRegistry` to register new services.