### PR TITLE
Add support for retrieving merchant KPI data from API

### DIFF
--- a/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/DataTransferObjects.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/DataTransferObjects.cs
@@ -11,4 +11,14 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects
         [JsonProperty("description")]
         public String Description { get; set; }
     }
+
+    public class MerchantKpi
+    {
+        [JsonProperty("merchants_with_sale_in_last_hour")]
+        public Int32 MerchantsWithSaleInLastHour { get; set; }
+        [JsonProperty("merchants_with_no_sale_today")]
+        public Int32 MerchantsWithNoSaleToday { get; set; }
+        [JsonProperty("merchants_with_no_sale_in_last7_days")]
+        public Int32 MerchantsWithNoSaleInLast7Days { get; set; }
+    }
 }

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/IEstateReportingApiClient.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/IEstateReportingApiClient.cs
@@ -10,6 +10,7 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
     public interface IEstateReportingApiClient
     {
         Task<Result<List<ComparisonDate>>> GetComparisonDates(String accessToken, Guid estateId, CancellationToken cancellationToken);
+        Task<Result<MerchantKpi>> GetMerchantKpi(String accessToken, Guid estateId, CancellationToken cancellationToken);
     }
 
     public class EstateReportingApiClient : ClientProxyBase.ClientProxyBase, IEstateReportingApiClient {
@@ -24,7 +25,7 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
         public async Task<Result<List<ComparisonDate>>> GetComparisonDates(String accessToken,
                                                                            Guid estateId,
                                                                            CancellationToken cancellationToken) {
-            String requestUri = this.BuildRequestUrl("/api/dimensions/calendar/comparisondates");
+            String requestUri = this.BuildRequestUrl("/api/calendars/comparisondates");
 
             try
             {
@@ -43,6 +44,31 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
             {
                 // An exception has occurred, add some additional information to the message
                 Exception exception = new Exception($"Error getting comparison dates for estate {estateId}.", ex);
+
+                return Result.Failure(exception.Message);
+            }
+        }
+
+        public async Task<Result<MerchantKpi>> GetMerchantKpi(String accessToken, Guid estateId, CancellationToken cancellationToken)
+        {
+            String requestUri = this.BuildRequestUrl("/api/merchants/kpis");
+
+            try
+            {
+                List<(String headerName, String headerValue)> additionalHeaders = [
+                    (EstateIdHeaderName, estateId.ToString())
+                ];
+                Result<MerchantKpi>? result = await this.SendHttpGetRequest<MerchantKpi>(requestUri, accessToken, additionalHeaders, cancellationToken);
+
+                if (result.IsFailed)
+                    return ResultHelpers.CreateFailure(result);
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                // An exception has occurred, add some additional information to the message
+                Exception exception = new Exception($"Error getting merchant kpis for estate {estateId}.", ex);
 
                 return Result.Failure(exception.Message);
             }

--- a/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
@@ -20,4 +20,14 @@ public static class APIModelFactory {
 
         return comparisonDates;
     }
+
+    public static MerchantKpiModel ConvertFrom(MerchantKpi apiResult) {
+        MerchantKpiModel model = new MerchantKpiModel {
+            MerchantsWithNoSaleInLast7Days = apiResult.MerchantsWithNoSaleInLast7Days, 
+            MerchantsWithNoSaleToday = apiResult.MerchantsWithNoSaleToday, 
+            MerchantsWithSaleInLastHour = apiResult.MerchantsWithSaleInLastHour
+        };
+
+        return model;
+    }
 }

--- a/EstateManagmentUI.BusinessLogic/Client/MerchantMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/MerchantMethods.cs
@@ -1,0 +1,27 @@
+﻿using EstateManagementUI.BusinessLogic.Models;
+using Shared.Results;
+using SimpleResults;
+
+namespace EstateManagementUI.BusinessLogic.Client
+{
+    public partial interface IApiClient
+    {
+        Task<Result<MerchantKpiModel>> GetMerchantKpi(String accessToken, Guid actionId, Guid estateId, CancellationToken cancellationToken);
+    }
+
+    public partial class ApiClient : IApiClient {
+        public async Task<Result<MerchantKpiModel>> GetMerchantKpi(String accessToken,
+                                                                   Guid actionId,
+                                                                   Guid estateId,
+                                                                   CancellationToken cancellationToken) {
+            var apiResult = await this.EstateReportingApiClient.GetMerchantKpi(accessToken, estateId, cancellationToken);
+
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            MerchantKpiModel merchantKpiModel = APIModelFactory.ConvertFrom(apiResult.Data);
+
+            return Result.Success(merchantKpiModel);
+        }
+    }
+}


### PR DESCRIPTION
Introduced MerchantKpi DTO and related model mapping to enable fetching merchant KPI data from the backend API. Updated IEstateReportingApiClient and ApiClient with new GetMerchantKpi methods, and refactored DashboardRequestHandler to use real API data instead of stubs. Adjusted endpoint URLs and dependency injection as needed. This allows the UI to display live merchant KPI statistics.

closes #598 
closes #597 
closes #596 