### PR TITLE
Add support for retrieving today's failed sales data

### DIFF
--- a/EstateManagementUI.BlazorServer/Components/Pages/Home.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Home.razor.cs
@@ -16,7 +16,7 @@ namespace EstateManagementUI.BlazorServer.Components.Pages
     public partial class Home
     {
         // Response code for low credit failures
-        private const string LOW_CREDIT_RESPONSE_CODE = "1008";
+        private const string LOW_CREDIT_RESPONSE_CODE = "1009";
 
         private bool isLoading = true;
         private bool isAdministrator;

--- a/EstateManagmentUI.BusinessLogic/Client/TransactionMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/TransactionMethods.cs
@@ -4,6 +4,7 @@ using SimpleResults;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects;
 using EstateManagementUI.BusinessLogic.Requests;
 
 namespace EstateManagementUI.BusinessLogic.Client
@@ -11,6 +12,7 @@ namespace EstateManagementUI.BusinessLogic.Client
     public partial interface IApiClient
     {
         Task<Result<TodaysSalesModel>> GetTodaysSales(Queries.GetTodaysSalesQuery request, CancellationToken cancellationToken);
+        Task<Result<TodaysSalesModel>> GetTodaysFailedSales(Queries.GetTodaysFailedSalesQuery request, CancellationToken cancellationToken);
     }
 
     public partial class ApiClient : IApiClient {
@@ -22,6 +24,24 @@ namespace EstateManagementUI.BusinessLogic.Client
                 return ResultHelpers.CreateFailure(token);
 
             var apiResult = await this.EstateReportingApiClient.GetTodaysSales(token.Data, request.EstateId, 0, 0, request.ComparisonDate, cancellationToken);
+
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            TodaysSalesModel todaysSalesModel = APIModelFactory.ConvertFrom(apiResult.Data);
+
+            return Result.Success(todaysSalesModel);
+        }
+
+        public async Task<Result<TodaysSalesModel>> GetTodaysFailedSales(Queries.GetTodaysFailedSalesQuery request,
+                                                                         CancellationToken cancellationToken)
+        {
+            // Get a token here 
+            Result<String> token = await this.GetToken(cancellationToken);
+            if (token.IsFailed)
+                return ResultHelpers.CreateFailure(token);
+
+            Result<TodaysSales> apiResult = await this.EstateReportingApiClient.GetTodaysFailedSales(token.Data, request.EstateId, 0, 0, request.ResponseCode, request.ComparisonDate, cancellationToken);
 
             if (apiResult.IsFailed)
                 return ResultHelpers.CreateFailure(apiResult);

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -3,10 +3,6 @@ using EstateManagementUI.BusinessLogic.Models;
 using EstateManagementUI.BusinessLogic.Requests;
 using MediatR;
 using SimpleResults;
-using System.Threading.Tasks;
-using SecurityService.Client;
-using SecurityService.DataTransferObjects.Responses;
-using Shared.Results;
 
 namespace EstateManagementUI.BusinessLogic.RequestHandlers
 {
@@ -288,7 +284,7 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
 
         public async Task<Result<TodaysSalesModel>> Handle(Queries.GetTodaysFailedSalesQuery request,
                                                            CancellationToken cancellationToken) {
-            return Result.Success(StubTestData.GetMockTodaysSales());
+            return await this.ApiClient.GetTodaysFailedSales(request, cancellationToken);
         }
 
         public async Task<Result<List<TopBottomProductDataModel>>> Handle(Queries.GetTopProductDataQuery request,


### PR DESCRIPTION
Introduced new methods in the API client and backend API interface to fetch today's failed sales by response code and date. Updated the request handler to use the new API client method, replacing stub data. This enables the UI to display failed sales information for a given estate, merchant, operator, and response code.

closes #600 