### PR TITLE
Enhance Estate Index with estate-level summary data

### DIFF
--- a/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
@@ -29,12 +29,10 @@ public class EstateIndexPageTests : BaseTest
         
         _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetEstateQuery>(), default))
             .ReturnsAsync(Result.Success(estate));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetMerchantsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<MerchantModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetContractsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<ContractModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetRecentMerchantsQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<RecentMerchantsModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetRecentContractsQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
         
         // Act
         var cut = RenderComponent<EstateIndex>();
@@ -57,18 +55,15 @@ public class EstateIndexPageTests : BaseTest
 
         _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetEstateQuery>(), default))
             .ReturnsAsync(Result.Success(estate));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetContractsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<ContractModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetMerchantsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<MerchantModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetRecentMerchantsQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<RecentMerchantsModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetRecentContractsQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
+
         // Act
         var cut = RenderComponent<EstateIndex>();
-        //cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
-
+        
         // Assert
-        //cut.Markup.ShouldContain("Test Estate");
         cut.WaitForAssertion(() => cut.Markup.ShouldContain("Test Estate"), timeout: TimeSpan.FromSeconds(5));
     }
 
@@ -78,13 +73,11 @@ public class EstateIndexPageTests : BaseTest
         // Arrange
         _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetEstateQuery>(), default))
             .ReturnsAsync(Result.Success(new EstateModel { EstateId = Guid.NewGuid() }));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetMerchantsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<MerchantModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetContractsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<ContractModel>()));
-        
+        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetRecentMerchantsQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<RecentMerchantsModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetRecentContractsQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
+
         // Act
         var cut = RenderComponent<EstateIndex>();
         

--- a/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor
@@ -62,7 +62,7 @@
                                 <div class="flex items-center justify-between">
                                     <div>
                                         <p class="text-sm text-gray-600 mb-1">Total Merchants</p>
-                                        <p class="text-3xl font-bold text-gray-900">@(merchants?.Count ?? 0)</p>
+                                        <p class="text-3xl font-bold text-gray-900">@(estate.Merchants?.Count ?? 0)</p>
                                     </div>
                                     <svg class="w-12 h-12 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"></path>
@@ -74,7 +74,7 @@
                                 <div class="flex items-center justify-between">
                                     <div>
                                         <p class="text-sm text-gray-600 mb-1">Total Operators</p>
-                                        <p class="text-3xl font-bold text-gray-900">@(assignedOperators?.Count ?? 0)</p>
+                                        <p class="text-3xl font-bold text-gray-900">@(estate.Operators?.Count ?? 0)</p>
                                     </div>
                                     <svg class="w-12 h-12 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"></path>
@@ -86,7 +86,7 @@
                                 <div class="flex items-center justify-between">
                                     <div>
                                         <p class="text-sm text-gray-600 mb-1">Total Contracts</p>
-                                        <p class="text-3xl font-bold text-gray-900">@(contracts?.Count ?? 0)</p>
+                                        <p class="text-3xl font-bold text-gray-900">@(estate.Operators?.Count ?? 0)</p>
                                     </div>
                                     <svg class="w-12 h-12 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
@@ -98,7 +98,7 @@
                                 <div class="flex items-center justify-between">
                                     <div>
                                         <p class="text-sm text-gray-600 mb-1">Total Users</p>
-                                        <p class="text-3xl font-bold text-gray-900">5</p>
+                                        <p class="text-3xl font-bold text-gray-900">@(estate.Users?.Count ?? 0)</p>
                                     </div>
                                     <svg class="w-12 h-12 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
@@ -118,12 +118,12 @@
                                 @if (merchants != null && merchants.Any())
                                 {
                                     <div class="space-y-3">
-                                        @foreach (var merchant in merchants.Take(5))
+                                        @foreach (var merchant in merchants)
                                         {
                                             <div class="flex items-center justify-between p-3 bg-white rounded-lg">
                                                 <div>
-                                                    <p class="font-medium text-gray-900">@merchant.MerchantName</p>
-                                                    <p class="text-sm text-gray-600">@merchant.MerchantReference</p>
+                                                    <p class="text-gray-900 font-medium">@merchant.Name (@merchant.Reference)</p>
+                                                    <p class="text-sm text-gray-500">@merchant.CreatedDateTime.ToString("dd/MM/yyyy HH:mm")</p>
                                                 </div>
                                                 <a href="/merchants/@merchant.MerchantId" class="text-blue-600 hover:text-blue-800">
                                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/EstateManagementUI.BlazorServer/Components/Pages/Home.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Home.razor
@@ -190,7 +190,6 @@
                                     </div>
                                     <div>
                                         <p class="text-gray-900 font-medium">@merchant.Name (@merchant.Reference)</p>
-                                        @* <p class="text-sm text-gray-500">@merchant.Reference</p> *@
                                         <p class="text-sm text-gray-500">@merchant.CreatedDateTime.ToString("dd/MM/yyyy HH:mm")</p>
                                     </div>
                                 </div>

--- a/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
+++ b/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
@@ -3,12 +3,39 @@
 namespace EstateManagementUI.BlazorServer.Factories {
     public static class ModelFactory {
         public static EstateModel ConvertFrom(BusinessLogic.Models.EstateModel model) {
-            EstateModel result = new EstateModel { EstateId = model.EstateId, EstateName = model.EstateName, Operators = new List<EstateOperatorModel>(), Reference = model.Reference };
+            EstateModel result = new EstateModel { EstateId = model.EstateId, EstateName = model.EstateName, 
+                Operators = new List<EstateOperatorModel>(), 
+                Contracts = new(),
+                Merchants = new(),
+                Users = new(),
+                Reference = model.Reference };
             if (model.Operators != null && model.Operators.Any()) {
                 model.Operators.ForEach((o) => result.Operators.Add(ConvertFrom(o)));
             }
+            if (model.Merchants != null && model.Merchants.Any()) {
+                model.Merchants.ForEach((m) => result.Merchants.Add(ConvertFrom(m)));
+            }
+            if (model.Contracts != null && model.Contracts.Any()) {
+                model.Contracts.ForEach((m) => result.Contracts.Add(ConvertFrom(m)));
+            }
+            if (model.Users != null && model.Users.Any())
+            {
+                model.Users.ForEach((m) => result.Users.Add(ConvertFrom(m)));
+            }
 
             return result;
+        }
+
+        private static EstateUserModel ConvertFrom(BusinessLogic.Models.EstateUserModel model) {
+            return new EstateUserModel() { CreatedDateTime = model.CreatedDateTime, EmailAddress = model.EmailAddress, UserId = model.UserId };
+        }
+
+        private static EstateContractModel ConvertFrom(BusinessLogic.Models.EstateContractModel model) {
+            return new EstateContractModel() { ContractId = model.ContractId, Name = model.Name, OperatorId = model.OperatorId, OperatorName = model.OperatorName };
+        }
+
+        private static EstateMerchantModel ConvertFrom(BusinessLogic.Models.EstateMerchantModel model) {
+            return new EstateMerchantModel() { Reference = model.Reference, Name = model.Name, MerchantId = model.MerchantId };
         }
 
         public static EstateOperatorModel ConvertFrom(BusinessLogic.Models.EstateOperatorModel model) {
@@ -299,7 +326,7 @@ namespace EstateManagementUI.BlazorServer.Factories {
             return result;
         }
 
-        public static List<RecentMerchantsModel>? ConvertFrom(List<BusinessLogic.Models.RecentMerchantsModel> models) {
+        public static List<RecentMerchantsModel> ConvertFrom(List<BusinessLogic.Models.RecentMerchantsModel> models) {
             List<RecentMerchantsModel> result = new List<RecentMerchantsModel>();
             models.ForEach(m => result.Add(ConvertFrom(m)));
             return result;
@@ -321,6 +348,16 @@ namespace EstateManagementUI.BlazorServer.Factories {
                 Town = model.Town
             };
             return result;
+        }
+
+        public static List<RecentContractModel> ConvertFrom(List<BusinessLogic.Models.RecentContractModel> models) {
+            List<RecentContractModel> result = new List<RecentContractModel>();
+            models.ForEach(m => result.Add(ConvertFrom(m)));
+            return result;
+        }
+
+        private static RecentContractModel ConvertFrom(BusinessLogic.Models.RecentContractModel model) {
+            return new RecentContractModel { OperatorName = model.OperatorName, Description = model.Description, ContractId = model.ContractId };
         }
     }
 }

--- a/EstateManagementUI.BlazorServer/Models/Models.cs
+++ b/EstateManagementUI.BlazorServer/Models/Models.cs
@@ -7,6 +7,16 @@ public class EstateModel
     public string? EstateName { get; set; }
     public string? Reference { get; set; }
     public List<EstateOperatorModel>? Operators { get; set; }
+    public List<EstateMerchantModel>? Merchants { get; set; }
+    public List<EstateContractModel>? Contracts { get; set; }
+    public List<EstateUserModel>? Users { get; set; }
+}
+
+public class EstateUserModel
+{
+    public Guid UserId { get; set; }
+    public string? EmailAddress { get; set; }
+    public DateTime CreatedDateTime { get; set; }
 }
 
 public class EstateOperatorModel
@@ -15,6 +25,23 @@ public class EstateOperatorModel
     public string? Name { get; set; }
     public bool RequireCustomMerchantNumber { get; set; }
     public bool RequireCustomTerminalNumber { get; set; }
+    public DateTime CreatedDateTime { get; set; }
+}
+
+public class EstateContractModel
+{
+    public Guid OperatorId { get; set; }
+    public Guid ContractId { get; set; }
+    public string? Name { get; set; }
+    public string? OperatorName { get; set; }
+}
+
+
+public class EstateMerchantModel
+{
+    public Guid MerchantId { get; set; }
+    public string? Name { get; set; }
+    public string? Reference { get; set; }
 }
 
 // Merchant Models
@@ -247,4 +274,11 @@ public class RecentMerchantsModel
     public String Reference { get; set; }
     public String Region { get; set; }
     public String Town { get; set; }
+}
+
+public class RecentContractModel
+{
+    public Guid ContractId { get; set; }
+    public string? Description { get; set; }
+    public string? OperatorName { get; set; }
 }

--- a/EstateManagementUI.BlazorServer/appsettings.Development.json
+++ b/EstateManagementUI.BlazorServer/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "AppSettings": {
-    "TestMode": "Full"
+    "TestMode": "Disabled"
   }
 }

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/DataTransferObjects.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/DataTransferObjects.cs
@@ -69,4 +69,92 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects
 
         #endregion
     }
+
+    public class Contract
+    {
+        #region Properties
+        [JsonProperty("estate_id")]
+        public Guid EstateId { get; set; }
+        [JsonProperty("estate_reporting_id")]
+        public Int32 EstateReportingId { get; set; }
+        [JsonProperty("contract_id")]
+        public Guid ContractId { get; set; }
+        [JsonProperty("contract_reporting_id")]
+        public Int32 ContractReportingId { get; set; }
+        [JsonProperty("description")]
+        public String Description { get; set; }
+        [JsonProperty("operator_name")]
+        public String OperatorName { get; set; }
+        [JsonProperty("operator_id")]
+        public Guid OperatorId { get; set; }
+        [JsonProperty("operator_reporting_id")]
+        public Int32 OperatorReportingId { get; set; }
+
+        #endregion
+    }
+
+    public class Estate
+    {
+        [JsonProperty("estate_id")]
+        public Guid EstateId { get; set; }
+        [JsonProperty("estate_name")]
+        public string? EstateName { get; set; }
+        [JsonProperty("reference")]
+        public string? Reference { get; set; }
+        [JsonProperty("operators")]
+        public List<EstateOperator>? Operators { get; set; }
+        [JsonProperty("merchants")]
+        public List<EstateMerchant>? Merchants { get; set; }
+        [JsonProperty("contracts")]
+        public List<EstateContract>? Contracts { get; set; }
+        [JsonProperty("users")]
+        public List<EstateUser>? Users { get; set; }
+    }
+
+    public class EstateUser
+    {
+        [JsonProperty("user_id")]
+        public Guid UserId { get; set; }
+        [JsonProperty("email_address")]
+        public string? EmailAddress { get; set; }
+        [JsonProperty("created_date_time")]
+        public DateTime CreatedDateTime { get; set; }
+    }
+
+    public class EstateOperator
+    {
+        [JsonProperty("operator_id")]
+        public Guid OperatorId { get; set; }
+        [JsonProperty("name")]
+        public string? Name { get; set; }
+        [JsonProperty("require_custom_merchant_number")]
+        public bool RequireCustomMerchantNumber { get; set; }
+        [JsonProperty("require_custom_terminal_number")]
+        public bool RequireCustomTerminalNumber { get; set; }
+        [JsonProperty("created_date_time")]
+        public DateTime CreatedDateTime { get; set; }
+    }
+
+    public class EstateContract
+    {
+        [JsonProperty("operator_id")]
+        public Guid OperatorId { get; set; }
+        [JsonProperty("contract_id")]
+        public Guid ContractId { get; set; }
+        [JsonProperty("name")]
+        public string? Name { get; set; }
+        [JsonProperty("operator_name")]
+        public string? OperatorName { get; set; }
+    }
+
+
+    public class EstateMerchant
+    {
+        [JsonProperty("merchant_id")]
+        public Guid MerchantId { get; set; }
+        [JsonProperty("name")]
+        public string? Name { get; set; }
+        [JsonProperty("reference")]
+        public string? Reference { get; set; }
+    }
 }

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/IEstateReportingApiClient.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/IEstateReportingApiClient.cs
@@ -9,12 +9,17 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
 {
     public interface IEstateReportingApiClient
     {
+        Task<Result<Estate>> GetEstate(String accessToken, Guid estateId, CancellationToken cancellationToken);
+
         Task<Result<List<ComparisonDate>>> GetComparisonDates(String accessToken, Guid estateId, CancellationToken cancellationToken);
         Task<Result<MerchantKpi>> GetMerchantKpi(String accessToken, Guid estateId, CancellationToken cancellationToken);
 
         Task<Result<List<Merchant>>> GetRecentMerchants(String accessToken,
                                                         Guid estateId,
                                                         CancellationToken cancellationToken);
+
+        Task<Result<List<Contract>>> GetRecentContracts(String accessToken,
+                                                        Guid estateId, CancellationToken cancellationToken);
         Task<Result<TodaysSales>> GetTodaysSales(String accessToken,
                                                  Guid estateId,
                                                  Int32 merchantReportingId,
@@ -32,6 +37,33 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
         public EstateReportingApiClient(Func<String, String> baseAddressResolver,
                                         HttpClient httpClient) : base(httpClient) {
             this.BaseAddressResolver = baseAddressResolver;
+        }
+
+        public async Task<Result<Estate>> GetEstate(String accessToken,
+                                                    Guid estateId,
+                                                    CancellationToken cancellationToken) {
+            String requestUri = this.BuildRequestUrl("/api/estates");
+
+            try
+            {
+                List<(String headerName, String headerValue)> additionalHeaders = [
+                    (EstateIdHeaderName, estateId.ToString())
+                ];
+
+                Result<Estate> result = await this.SendHttpGetRequest<Estate>(requestUri, accessToken, additionalHeaders, cancellationToken);
+
+                if (result.IsFailed)
+                    return ResultHelpers.CreateFailure(result);
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                // An exception has occurred, add some additional information to the message
+                Exception exception = new Exception($"Error getting estate {estateId}.", ex);
+
+                return Result.Failure(exception.Message);
+            }
         }
 
         public async Task<Result<List<ComparisonDate>>> GetComparisonDates(String accessToken,
@@ -96,6 +128,32 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
                     (EstateIdHeaderName, estateId.ToString())
                 ];
                 Result<List<Merchant>> result = await this.SendHttpGetRequest<List<Merchant>>(requestUri, accessToken, additionalHeaders, cancellationToken);
+
+                if (result.IsFailed)
+                    return ResultHelpers.CreateFailure(result);
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                // An exception has occurred, add some additional information to the message
+                Exception exception = new Exception($"Error getting recent merchants for estate {estateId}.", ex);
+
+                return Result.Failure(exception.Message);
+            }
+        }
+
+        public async Task<Result<List<Contract>>> GetRecentContracts(String accessToken,
+                                                                     Guid estateId,
+                                                                     CancellationToken cancellationToken) {
+            String requestUri = this.BuildRequestUrl("/api/contracts/recent");
+
+            try
+            {
+                List<(String headerName, String headerValue)> additionalHeaders = [
+                    (EstateIdHeaderName, estateId.ToString())
+                ];
+                Result<List<Contract>> result = await this.SendHttpGetRequest<List<Contract>>(requestUri, accessToken, additionalHeaders, cancellationToken);
 
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);

--- a/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
@@ -68,23 +68,69 @@ public static class APIModelFactory {
         return merchants;
     }
 
-    public static EstateModel ConvertFrom(EstateResponse apiResultData) {
-        EstateModel model = new EstateModel {
-            Reference = apiResultData.EstateReference,
+    public static EstateModel ConvertFrom(Estate apiResultData) {
+        EstateModel model = new() {
+            Reference = apiResultData.Reference,
             EstateId = apiResultData.EstateId,
             EstateName = apiResultData.EstateName,
-            Operators = new List<EstateOperatorModel>()
+            Operators = new(),
+            Users = new(),
+            Contracts = new(),
+            Merchants = new ()
         };
 
-        foreach (EstateOperatorResponse estateOperatorResponse in apiResultData.Operators) {
+        foreach (var estateOperator in apiResultData.Operators) {
             model.Operators.Add(new EstateOperatorModel {
-                Name = estateOperatorResponse.Name,
-                OperatorId = estateOperatorResponse.OperatorId,
-                RequireCustomMerchantNumber = estateOperatorResponse.RequireCustomMerchantNumber,
-                RequireCustomTerminalNumber = estateOperatorResponse.RequireCustomTerminalNumber,
+                Name = estateOperator.Name,
+                OperatorId = estateOperator.OperatorId,
+                RequireCustomMerchantNumber = estateOperator.RequireCustomMerchantNumber,
+                RequireCustomTerminalNumber = estateOperator.RequireCustomTerminalNumber,
+            });
+        }
+        foreach (var estateMerchant in apiResultData.Merchants)
+        {
+            model.Merchants.Add(new EstateMerchantModel()
+            {
+                Name = estateMerchant.Name,
+                Reference = estateMerchant.Reference,
+                MerchantId = estateMerchant.MerchantId
+            });
+        }
+        foreach (var estateContract in apiResultData.Contracts)
+        {
+            model.Contracts.Add(new EstateContractModel()
+            {
+                Name = estateContract.Name,
+                OperatorId = estateContract.OperatorId,
+                ContractId = estateContract.ContractId,
+                OperatorName = estateContract.OperatorName
+            });
+        }
+        foreach (var estateUser in apiResultData.Users)
+        {
+            model.Users.Add(new EstateUserModel()
+            {
+                CreatedDateTime = estateUser.CreatedDateTime,
+                EmailAddress = estateUser.EmailAddress,
+                UserId = estateUser.UserId
+            });
+        }
+        
+
+        return model;
+    }
+
+    public static List<RecentContractModel> ConvertFrom(List<Contract> apiResultData) {
+        List<RecentContractModel> contracts = new();
+
+        foreach (Contract contract in apiResultData) {
+            contracts.Add(new RecentContractModel {
+                ContractId = contract.ContractId,
+                Description = contract.Description,
+                OperatorName = contract.OperatorName
             });
         }
 
-        return model;
+        return contracts;
     }
 }

--- a/EstateManagmentUI.BusinessLogic/Client/EstateMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/EstateMethods.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Text;
+using EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects;
 using Shared.Results;
 using TransactionProcessor.DataTransferObjects.Responses.Estate;
 
@@ -23,7 +24,7 @@ namespace EstateManagementUI.BusinessLogic.Client {
             if (token.IsFailed)
                 return ResultHelpers.CreateFailure(token);
 
-            Result<EstateResponse>? apiResult = await this.TransactionProcessorClient.GetEstate(token.Data, request.EstateId, cancellationToken);
+            Result<Estate>? apiResult = await this.EstateReportingApiClient.GetEstate(token.Data, request.EstateId, cancellationToken);
             if (apiResult.IsFailed)
                 return ResultHelpers.CreateFailure(apiResult);
 

--- a/EstateManagmentUI.BusinessLogic/Client/MerchantMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/MerchantMethods.cs
@@ -11,6 +11,7 @@ namespace EstateManagementUI.BusinessLogic.Client
     {
         Task<Result<MerchantKpiModel>> GetMerchantKpi(Queries.GetMerchantKpiQuery request, CancellationToken cancellationToken);
         Task<Result<List<RecentMerchantsModel>>> GetRecentMerchants(Queries.GetRecentMerchantsQuery request, CancellationToken cancellationToken);
+        Task<Result<List<RecentContractModel>>> GetRecentContracts(Queries.GetRecentContractsQuery request, CancellationToken cancellationToken);
     }
 
     public partial class ApiClient : IApiClient {
@@ -46,6 +47,22 @@ namespace EstateManagementUI.BusinessLogic.Client
             List<RecentMerchantsModel> recentMerchantsModels = APIModelFactory.ConvertFrom(apiResult.Data);
 
             return Result.Success(recentMerchantsModels);
+        }
+
+        public async Task<Result<List<RecentContractModel>>> GetRecentContracts(Queries.GetRecentContractsQuery request,
+                                                                                CancellationToken cancellationToken) {
+            Result<String> token = await this.GetToken(cancellationToken);
+            if (token.IsFailed)
+                return ResultHelpers.CreateFailure(token);
+
+            Result<List<Contract>> apiResult = await this.EstateReportingApiClient.GetRecentContracts(token.Data, request.EstateId, cancellationToken);
+
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            List<RecentContractModel> recentContractModels = APIModelFactory.ConvertFrom(apiResult.Data);
+
+            return Result.Success(recentContractModels);
         }
     }
 }

--- a/EstateManagmentUI.BusinessLogic/Models/Models.cs
+++ b/EstateManagmentUI.BusinessLogic/Models/Models.cs
@@ -7,6 +7,15 @@ public class EstateModel
     public string? EstateName { get; set; }
     public string? Reference { get; set; }
     public List<EstateOperatorModel>? Operators { get; set; }
+    public List<EstateMerchantModel>? Merchants { get; set; }
+    public List<EstateContractModel>? Contracts { get; set; }
+    public List<EstateUserModel>? Users { get; set; }
+}
+
+public class EstateUserModel {
+    public Guid UserId { get; set; }
+    public string? EmailAddress { get; set; }
+    public DateTime CreatedDateTime { get; set; }
 }
 
 public class EstateOperatorModel
@@ -15,7 +24,24 @@ public class EstateOperatorModel
     public string? Name { get; set; }
     public bool RequireCustomMerchantNumber { get; set; }
     public bool RequireCustomTerminalNumber { get; set; }
+    public DateTime CreatedDateTime { get; set; }
 }
+
+public class EstateContractModel
+{
+    public Guid OperatorId { get; set; }
+    public Guid ContractId { get; set; }
+    public string? Name { get; set; }
+    public string? OperatorName { get; set; }
+}
+
+
+public class EstateMerchantModel {
+    public Guid MerchantId { get; set; }
+    public string? Name { get; set; }
+    public string? Reference { get; set; }
+}
+
 
 // Merchant Models
 public class MerchantModel
@@ -272,3 +298,11 @@ public class RecentMerchantsModel
     public String Region { get; set; }
     public String Town { get; set; }
 }
+
+public class RecentContractModel
+{
+    public Guid ContractId { get; set; }
+    public string? Description { get; set; }
+    public string? OperatorName { get; set; }
+}
+

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -148,7 +148,8 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
                                             IRequestHandler<Queries.GetContractQuery, Result<ContractModel>>,
                                             IRequestHandler<Commands.CreateContractCommand, Result>,
                                             IRequestHandler<Commands.AddProductToContractCommand, Result>,
-                                            IRequestHandler<Commands.AddTransactionFeeForProductToContractCommand, Result> {
+                                            IRequestHandler<Commands.AddTransactionFeeForProductToContractCommand, Result>,
+    IRequestHandler<Queries.GetRecentContractsQuery, Result<List<RecentContractModel>>> {
 
         private readonly IApiClient ApiClient;
 
@@ -180,6 +181,11 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
         public async Task<Result> Handle(Commands.AddTransactionFeeForProductToContractCommand request,
                                          CancellationToken cancellationToken) {
             return Result.Success();
+        }
+
+        public async Task<Result<List<RecentContractModel>>> Handle(Queries.GetRecentContractsQuery request,
+                                                                    CancellationToken cancellationToken) {
+            return await this.ApiClient.GetRecentContracts(request, cancellationToken);
         }
     }
 

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -16,6 +16,7 @@ public static class Queries
     public record GetEstateQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<EstateModel>>;
     public record GetMerchantsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<MerchantModel>>>;
     public record GetRecentMerchantsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<RecentMerchantsModel>>>;
+    public record GetRecentContractsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<RecentContractModel>>>;
     public record GetOperatorsQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId) : IRequest<Result<List<OperatorModel>>>;
     public record GetContractsQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId) : IRequest<Result<List<ContractModel>>>;
     public record GetOperatorQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid OperatorId) : IRequest<Result<OperatorModel>>;

--- a/EstateManagmentUI.BusinessLogic/Services/TestDataStore.cs
+++ b/EstateManagmentUI.BusinessLogic/Services/TestDataStore.cs
@@ -1,5 +1,6 @@
-using System.Collections.Concurrent;
+using EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects;
 using EstateManagementUI.BusinessLogic.Models;
+using System.Collections.Concurrent;
 
 namespace EstateManagementUI.BusinessLogic.Services;
 
@@ -35,6 +36,28 @@ public class TestDataStore : ITestDataStore
                     RequireCustomTerminalNumber = o.RequireCustomTerminalNumber
                 }).ToList();
             }
+            if (this._contracts.TryGetValue(estateId, out var contractDict))
+            {
+                estate.Contracts = contractDict.Values.Select(o => new EstateContractModel()
+                {
+                    OperatorId = o.OperatorId,
+                    Name = o.Description,
+                    OperatorName = o.OperatorName,
+                    ContractId = o.ContractId
+                }).ToList();
+            }
+            if (this._merchants.TryGetValue(estateId, out var merchantDict))
+            {
+                estate.Merchants = merchantDict.Values.Select(o => new EstateMerchantModel()
+                {
+                    Name = o.MerchantName,
+                    Reference = o.MerchantReference,
+                    MerchantId = o.MerchantId
+                }).ToList();
+            }
+
+            estate.Users = [new EstateUserModel { CreatedDateTime = DateTime.Now, EmailAddress = "estatedevuser1@estate.co.uk", UserId = Guid.Parse("61BFC7DC-FDB4-408A-9CAA-B9F0CF690130") }];
+
             return estate;
         }
         
@@ -207,7 +230,7 @@ public class TestDataStore : ITestDataStore
         {
             EstateId = estateId,
             EstateName = "Test Estate",
-            Reference = "Test Estate"
+            Reference = "Test Estate",
         };
         this.SetEstate(estate);
 


### PR DESCRIPTION
Refactor Estate Index to display total merchants, contracts, operators, and users by extending EstateModel and related models. Add new DTOs and API client methods to fetch estate details and recent contracts. Update UI, model factories, test data, and tests to support new structure. Set TestMode to "Disabled" in development settings.

closes #605 
closes #606 
closes #607 
closes #608 
closes #609 
closes #610 