### PR TITLE
Add support for displaying assigned operators per estate

### DIFF
--- a/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
@@ -33,7 +33,9 @@ public class EstateIndexPageTests : BaseTest
             .ReturnsAsync(Result.Success(new List<RecentMerchantsModel>()));
         _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetRecentContractsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
-        
+        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetAssignedOperatorsQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
+
         // Act
         var cut = RenderComponent<EstateIndex>();
         
@@ -59,6 +61,8 @@ public class EstateIndexPageTests : BaseTest
             .ReturnsAsync(Result.Success(new List<RecentMerchantsModel>()));
         _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetRecentContractsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetAssignedOperatorsQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
 
         // Act
         var cut = RenderComponent<EstateIndex>();
@@ -77,6 +81,8 @@ public class EstateIndexPageTests : BaseTest
             .ReturnsAsync(Result.Success(new List<RecentMerchantsModel>()));
         _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetRecentContractsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetAssignedOperatorsQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
 
         // Act
         var cut = RenderComponent<EstateIndex>();

--- a/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor.cs
@@ -60,8 +60,6 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Estate
             if (merchantResult.IsFailed)
                 return ResultHelpers.CreateFailure(merchantResult);
 
-            // Note: API returns merchants in creation order (newest first)
-            // If ordering is incorrect, would need CreatedDate field in the model
             this.merchants = ModelFactory.ConvertFrom(merchantResult.Data);
 
             Result<List<BusinessLogic.Models.RecentContractModel>> contractResult = await Mediator.Send(new Queries.GetRecentContractsQuery(correlationId, estateId));
@@ -69,9 +67,14 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Estate
             if (contractResult.IsFailed)
                 return ResultHelpers.CreateFailure(contractResult);
 
-            // Note: API returns merchants in creation order (newest first)
-            // If ordering is incorrect, would need CreatedDate field in the model
             this.contracts = ModelFactory.ConvertFrom(contractResult.Data);
+
+            Result<List<BusinessLogic.Models.OperatorModel>> assignedOperatorsResult = await Mediator.Send(new Queries.GetAssignedOperatorsQuery(correlationId, estateId));
+
+            if (assignedOperatorsResult.IsFailed)
+                return ResultHelpers.CreateFailure(assignedOperatorsResult);
+
+            this.assignedOperators = ModelFactory.ConvertFrom(assignedOperatorsResult.Data);
 
             return Result.Success();
         }

--- a/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
+++ b/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
@@ -62,6 +62,13 @@ namespace EstateManagementUI.BlazorServer.Factories {
             };
         }
 
+        public static List<OperatorModel> ConvertFrom(List<BusinessLogic.Models.OperatorModel> models)
+        {
+            List<OperatorModel> result = new List<OperatorModel>();
+            models.ForEach(m => result.Add(ConvertFrom(m)));
+            return result;
+        }
+
         public static OperatorModel ConvertFrom(BusinessLogic.Models.OperatorModel model) {
             return new OperatorModel() { OperatorId = model.OperatorId, Name = model.Name, RequireCustomMerchantNumber = model.RequireCustomMerchantNumber, RequireCustomTerminalNumber = model.RequireCustomTerminalNumber };
         }
@@ -220,11 +227,7 @@ namespace EstateManagementUI.BlazorServer.Factories {
             return new ProductPerformanceModel() { PercentageContribution = model.PercentageContribution, ProductName = model.ProductName, TransactionCount = model.TransactionCount, TransactionValue = model.TransactionValue };
         }
 
-        public static List<OperatorModel> ConvertFrom(List<BusinessLogic.Models.OperatorModel> models) {
-            List<OperatorModel> result = new List<OperatorModel>();
-            models.ForEach(m => result.Add(ConvertFrom(m)));
-            return result;
-        }
+        
 
         public static List<MerchantModel> ConvertFrom(List<BusinessLogic.Models.MerchantModel> models) {
             List<MerchantModel> result = new List<MerchantModel>();
@@ -355,7 +358,7 @@ namespace EstateManagementUI.BlazorServer.Factories {
             models.ForEach(m => result.Add(ConvertFrom(m)));
             return result;
         }
-
+        
         private static RecentContractModel ConvertFrom(BusinessLogic.Models.RecentContractModel model) {
             return new RecentContractModel { OperatorName = model.OperatorName, Description = model.Description, ContractId = model.ContractId };
         }

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/IEstateReportingApiClient.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/IEstateReportingApiClient.cs
@@ -11,6 +11,9 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
     {
         Task<Result<Estate>> GetEstate(String accessToken, Guid estateId, CancellationToken cancellationToken);
 
+        Task<Result<List<EstateOperator>>> GetEstateAssignedOperators(String accessToken,
+                                                                      Guid estateId,
+                                                                      CancellationToken cancellationToken);
         Task<Result<List<ComparisonDate>>> GetComparisonDates(String accessToken, Guid estateId, CancellationToken cancellationToken);
         Task<Result<MerchantKpi>> GetMerchantKpi(String accessToken, Guid estateId, CancellationToken cancellationToken);
 
@@ -61,6 +64,34 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
             {
                 // An exception has occurred, add some additional information to the message
                 Exception exception = new Exception($"Error getting estate {estateId}.", ex);
+
+                return Result.Failure(exception.Message);
+            }
+        }
+
+        public async Task<Result<List<EstateOperator>>> GetEstateAssignedOperators(String accessToken,
+                                                                                   Guid estateId,
+                                                                                   CancellationToken cancellationToken)
+        {
+            String requestUri = this.BuildRequestUrl("/api/estates/operators");
+
+            try
+            {
+                List<(String headerName, String headerValue)> additionalHeaders = [
+                    (EstateIdHeaderName, estateId.ToString())
+                ];
+
+                Result<List<EstateOperator>> result = await this.SendHttpGetRequest<List<EstateOperator>>(requestUri, accessToken, additionalHeaders, cancellationToken);
+
+                if (result.IsFailed)
+                    return ResultHelpers.CreateFailure(result);
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                // An exception has occurred, add some additional information to the message
+                Exception exception = new Exception($"Error getting estate assigned operators {estateId}.", ex);
 
                 return Result.Failure(exception.Message);
             }

--- a/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
@@ -133,4 +133,17 @@ public static class APIModelFactory {
 
         return contracts;
     }
+
+    public static List<OperatorModel> ConvertFrom(List<EstateOperator> apiResultData) {
+        List<OperatorModel> operators = new();
+        foreach (EstateOperator estateOperator in apiResultData) {
+            operators.Add(new OperatorModel() {
+                Name = estateOperator.Name,
+                OperatorId = estateOperator.OperatorId,
+                RequireCustomMerchantNumber = estateOperator.RequireCustomMerchantNumber,
+                RequireCustomTerminalNumber = estateOperator.RequireCustomTerminalNumber
+            });
+        }
+        return operators;
+    }
 }

--- a/EstateManagmentUI.BusinessLogic/Client/EstateMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/EstateMethods.cs
@@ -13,6 +13,9 @@ namespace EstateManagementUI.BusinessLogic.Client {
     public partial interface IApiClient {
         Task<Result<EstateModel>> GetEstate(Queries.GetEstateQuery request,
                                             CancellationToken cancellationToken);
+
+        Task<Result<List<OperatorModel>>> GetEstateAssignedOperators(Queries.GetAssignedOperatorsQuery request,
+                                                                           CancellationToken cancellationToken);
     }
 
     public partial class ApiClient : IApiClient {
@@ -31,6 +34,22 @@ namespace EstateManagementUI.BusinessLogic.Client {
             EstateModel estate = APIModelFactory.ConvertFrom(apiResult.Data);
 
             return Result.Success(estate);
+        }
+
+        public async Task<Result<List<OperatorModel>>> GetEstateAssignedOperators(Queries.GetAssignedOperatorsQuery request,
+                                                                                        CancellationToken cancellationToken) {
+            // Get a token here 
+            Result<String> token = await this.GetToken(cancellationToken);
+            if (token.IsFailed)
+                return ResultHelpers.CreateFailure(token);
+
+            Result<List<EstateOperator>>? apiResult = await this.EstateReportingApiClient.GetEstateAssignedOperators(token.Data, request.EstateId, cancellationToken);
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            List<OperatorModel> estateOperators = APIModelFactory.ConvertFrom(apiResult.Data);
+
+            return Result.Success(estateOperators);
         }
     }
 }

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -21,8 +21,8 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
 
     public class EstateRequestHandler : IRequestHandler<Queries.GetEstateQuery, Result<EstateModel>>,
         IRequestHandler<Commands.AddOperatorToEstateCommand, Result>,
-        IRequestHandler<Commands.RemoveOperatorFromEstateCommand, Result>
-    {
+        IRequestHandler<Commands.RemoveOperatorFromEstateCommand, Result>,
+        IRequestHandler<Queries.GetAssignedOperatorsQuery, Result<List<OperatorModel>>> {
         private readonly IApiClient ApiClient;
 
         public EstateRequestHandler(IApiClient apiClient) {
@@ -42,6 +42,11 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
         public async Task<Result> Handle(Commands.RemoveOperatorFromEstateCommand request,
                                          CancellationToken cancellationToken) {
             return Result.Success();
+        }
+
+        public async Task<Result<List<OperatorModel>>> Handle(Queries.GetAssignedOperatorsQuery request,
+                                                              CancellationToken cancellationToken) {
+            return await this.ApiClient.GetEstateAssignedOperators(request, cancellationToken);
         }
     }
 

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -14,6 +14,7 @@ public static class CorrelationIdHelper
 public static class Queries
 {
     public record GetEstateQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<EstateModel>>;
+    public record GetAssignedOperatorsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<OperatorModel>>>;
     public record GetMerchantsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<MerchantModel>>>;
     public record GetRecentMerchantsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<RecentMerchantsModel>>>;
     public record GetRecentContractsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<RecentContractModel>>>;


### PR DESCRIPTION
Introduced GetAssignedOperatorsQuery and updated the backend API client to fetch assigned operators for an estate. Updated model factories for conversion, extended EstateRequestHandler, and modified the EstateIndex page to load and display assigned operators. Adjusted unit tests to mock and verify the new behavior. This enhances estate management by showing currently assigned operators in the UI.

closes #611 