### PR TITLE
Refactor estate operator add/remove to centralize token logic

### DIFF
--- a/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor.cs
@@ -105,13 +105,11 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Estate
             try
             {
                 var correlationId = new CorrelationId(Guid.NewGuid());
-                var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-                var accessToken = "stubbed-token";
+                Guid estateId = await this.GetEstateId();
                 var operatorId = Guid.Parse(selectedOperatorId);
 
                 var command = new Commands.AddOperatorToEstateCommand(
                     correlationId,
-                    accessToken,
                     estateId,
                     operatorId
                 );
@@ -149,12 +147,9 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Estate
             try
             {
                 var correlationId = new CorrelationId(Guid.NewGuid());
-                var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-                var accessToken = "stubbed-token";
-
+                Guid estateId = await this.GetEstateId();
                 var command = new Commands.RemoveOperatorFromEstateCommand(
                     correlationId,
-                    accessToken,
                     estateId,
                     operatorId
                 );

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -36,12 +36,12 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
 
         public async Task<Result> Handle(Commands.AddOperatorToEstateCommand request,
                                          CancellationToken cancellationToken) {
-            return Result.Success();
+            return await this.ApiClient.AddEstateOperator(request, cancellationToken);
         }
 
         public async Task<Result> Handle(Commands.RemoveOperatorFromEstateCommand request,
                                          CancellationToken cancellationToken) {
-            return Result.Success();
+            return await this.ApiClient.RemoveEstateOperator(request, cancellationToken);
         }
 
         public async Task<Result<List<OperatorModel>>> Handle(Queries.GetAssignedOperatorsQuery request,

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -54,7 +54,7 @@ public static class Commands
 {
     public record AddMerchantDeviceCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, string DeviceIdentifier) : IRequest<Result>;
     public record AddOperatorToMerchantCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, Guid OperatorId, string? MerchantNumber, string? TerminalNumber) : IRequest<Result>;
-    public record AddOperatorToEstateCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid OperatorId) : IRequest<Result>;
+    public record AddOperatorToEstateCommand(CorrelationId CorrelationId, Guid EstateId, Guid OperatorId) : IRequest<Result>;
     public record AssignContractToMerchantCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, Guid ContractId) : IRequest<Result>;
     public record CreateContractCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, string Description, Guid OperatorId) : IRequest<Result>;
     public record CreateMerchantCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, string Name, string ContactName, string ContactEmail) : IRequest<Result>;
@@ -63,7 +63,7 @@ public static class Commands
     public record MakeMerchantDepositCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, decimal Amount, DateTime Date, string Reference) : IRequest<Result>;
     public record RemoveContractFromMerchantCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, Guid ContractId) : IRequest<Result>;
     public record RemoveOperatorFromMerchantCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, Guid OperatorId) : IRequest<Result>;
-    public record RemoveOperatorFromEstateCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid OperatorId) : IRequest<Result>;
+    public record RemoveOperatorFromEstateCommand(CorrelationId CorrelationId, Guid EstateId, Guid OperatorId) : IRequest<Result>;
     public record SetMerchantSettlementScheduleCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, string Schedule) : IRequest<Result>;
     public record SwapMerchantDeviceCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, string OldDevice, string NewDevice) : IRequest<Result>;
     public record UpdateMerchantAddressCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, string AddressLine1, string Town, string Region, string PostalCode, string Country) : IRequest<Result>;


### PR DESCRIPTION
- Remove AccessToken from Add/RemoveOperatorToEstate commands
- Retrieve estateId dynamically in UI; no hardcoded values
- Add AddEstateOperator/RemoveEstateOperator to IApiClient
- API client now handles token acquisition internally
- Request handlers delegate directly to API client methods
- Simplifies command signatures and improves maintainability
closes #614 
closes #613 