### PR TITLE
Refactor RemoveContractFromMerchant command usage

### DIFF
--- a/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor.cs
@@ -172,8 +172,9 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Merchants
                 return ResultHelpers.CreateFailure(result);
             }
             
-            availableContracts = ModelFactory.ConvertFrom(result.Data);
-            
+            var unfiltered = ModelFactory.ConvertFrom(result.Data);
+            this.availableContracts = unfiltered.Where(u => this.assignedContracts.Select(a => a.ContractId).Contains(u.ContractId) == false).ToList();
+
             return Result.Success();
         }
 
@@ -457,12 +458,10 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Merchants
             try
             {
                 var correlationId = new CorrelationId(Guid.NewGuid());
-                var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-                var accessToken = "stubbed-token";
+                var estateId = await this.GetEstateId();
 
-                var command = new Commands.RemoveContractFromMerchantCommand(
+                var command = new MerchantCommands.RemoveContractFromMerchantCommand(
                     correlationId,
-                    accessToken,
                     estateId,
                     MerchantId,
                     contractId

--- a/EstateManagmentUI.BusinessLogic/Client/MerchantMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/MerchantMethods.cs
@@ -25,6 +25,7 @@ namespace EstateManagementUI.BusinessLogic.Client
         Task<Result> UpdateMerchantContact(MerchantCommands.UpdateMerchantCommand request, CancellationToken cancellationToken);
         Task<Result> RemoveOperatorFromMerchant(MerchantCommands.RemoveOperatorFromMerchantCommand request, CancellationToken cancellationToken);
         Task<Result> AddOperatorToMerchant(MerchantCommands.AddOperatorToMerchantCommand request, CancellationToken cancellationToken);
+        Task<Result> RemoveContractFromMerchant(MerchantCommands.RemoveContractFromMerchantCommand request, CancellationToken cancellationToken);
     }
 
     public partial class ApiClient : IApiClient {
@@ -37,13 +38,27 @@ namespace EstateManagementUI.BusinessLogic.Client
                 return ResultHelpers.CreateFailure(token);
 
             var apiRequest = new AssignOperatorRequest { TerminalNumber = request.TerminalNumber, MerchantNumber = request.MerchantNumber, OperatorId = request.OperatorId };
-
+            
             var apiResult = await this.TransactionProcessorClient.AssignOperatorToMerchant(token.Data, request.EstateId, request.MerchantId, apiRequest, cancellationToken);
             if (apiResult.IsFailed)
                 return ResultHelpers.CreateFailure(apiResult);
 
             return Result.Success();
         }
+
+        public async Task<Result> RemoveContractFromMerchant(MerchantCommands.RemoveContractFromMerchantCommand request,
+                                                             CancellationToken cancellationToken) {
+            var token = await this.GetToken(cancellationToken);
+            if (token.IsFailed)
+                return ResultHelpers.CreateFailure(token);
+
+            var apiResult = await this.TransactionProcessorClient.RemoveContractFromMerchant(token.Data, request.EstateId, request.MerchantId, request.ContractId, cancellationToken);
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            return Result.Success();
+        }
+
         public async Task<Result> RemoveOperatorFromMerchant(MerchantCommands.RemoveOperatorFromMerchantCommand request,
                                                              CancellationToken cancellationToken) {
             var token = await this.GetToken(cancellationToken);
@@ -274,3 +289,4 @@ namespace EstateManagementUI.BusinessLogic.Client
         }
     }
 }
+

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -57,7 +57,7 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
                                         IRequestHandler<MerchantCommands.AddOperatorToMerchantCommand, Result>,
                                         IRequestHandler<Commands.CreateMerchantCommand, Result>,
                                         IRequestHandler<Commands.MakeMerchantDepositCommand, Result>,
-                                        IRequestHandler<Commands.RemoveContractFromMerchantCommand, Result>,
+                                        IRequestHandler<MerchantCommands.RemoveContractFromMerchantCommand, Result>,
                                         IRequestHandler<MerchantCommands.RemoveOperatorFromMerchantCommand, Result>,
                                         IRequestHandler<Commands.SwapMerchantDeviceCommand, Result>,
                                         IRequestHandler<MerchantCommands.UpdateMerchantCommand, Result>,
@@ -101,9 +101,9 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
             return Result.Success();
         }
 
-        public async Task<Result> Handle(Commands.RemoveContractFromMerchantCommand request,
+        public async Task<Result> Handle(MerchantCommands.RemoveContractFromMerchantCommand request,
                                          CancellationToken cancellationToken) {
-            return Result.Success();
+            return await this.ApiClient.RemoveContractFromMerchant(request, cancellationToken);
         }
 
         public async Task<Result> Handle(MerchantCommands.RemoveOperatorFromMerchantCommand request,

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -73,6 +73,7 @@ public static class MerchantCommands {
     public record UpdateMerchantCommand(CorrelationId CorrelationId,Guid EstateId, Guid MerchantId, string Name, String SettlementSchedule, MerchantAddress MerchantAddress, MerchantContact MerchantContact) : IRequest<Result>;
     public record RemoveOperatorFromMerchantCommand(CorrelationId CorrelationId, Guid EstateId, Guid MerchantId, Guid OperatorId) : IRequest<Result>;
     public record AddOperatorToMerchantCommand(CorrelationId CorrelationId, Guid EstateId, Guid MerchantId, Guid OperatorId, string? MerchantNumber, string? TerminalNumber) : IRequest<Result>;
+    public record RemoveContractFromMerchantCommand(CorrelationId CorrelationId, Guid EstateId, Guid MerchantId, Guid ContractId) : IRequest<Result>;
 }
 
 public static class Commands
@@ -84,7 +85,6 @@ public static class Commands
     public record CreateMerchantUserCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, string EmailAddress, string Password) : IRequest<Result>;
     public record CreateOperatorCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, string Name, bool RequireCustomMerchantNumber, bool RequireCustomTerminalNumber) : IRequest<Result>;
     public record MakeMerchantDepositCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, decimal Amount, DateTime Date, string Reference) : IRequest<Result>;
-    public record RemoveContractFromMerchantCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, Guid ContractId) : IRequest<Result>;
     
     public record SwapMerchantDeviceCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, string OldDevice, string NewDevice) : IRequest<Result>;
     public record UpdateOperatorCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid OperatorId, string Name, bool RequireCustomMerchantNumber, bool RequireCustomTerminalNumber) : IRequest<Result>;

--- a/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
+++ b/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
@@ -75,7 +75,7 @@ public class TestMediatorService : IMediator
             Commands.AddProductToContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddProductToContract(cmd)),
             Commands.AddTransactionFeeForProductToContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddTransactionFee(cmd)),
             Commands.AssignContractToMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAssignContractToMerchant(cmd)),
-            Commands.RemoveContractFromMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteRemoveContractFromMerchant(cmd)),
+            MerchantCommands.RemoveContractFromMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteRemoveContractFromMerchant(cmd)),
             MerchantCommands.AddOperatorToMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddOperatorToMerchant(cmd)),
             MerchantCommands.RemoveOperatorFromMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteRemoveOperatorFromMerchant(cmd)),
             EstateCommands.AddOperatorToEstateCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddOperatorToEstate(cmd)),
@@ -272,7 +272,7 @@ public class TestMediatorService : IMediator
         return Result.Success();
     }
 
-    private Result ExecuteRemoveContractFromMerchant(Commands.RemoveContractFromMerchantCommand cmd)
+    private Result ExecuteRemoveContractFromMerchant(MerchantCommands.RemoveContractFromMerchantCommand cmd)
     {
         var merchant = this._testDataStore.GetMerchant(cmd.EstateId, cmd.MerchantId);
         if (merchant == null)


### PR DESCRIPTION
Refactored RemoveContractFromMerchant to use MerchantCommands namespace throughout the codebase. Removed access token from the command signature and now handle it internally in the API client. Updated IApiClient, request handler, and test mediator to support the new command structure. Improved contract filtering in Edit.razor.cs to only show unassigned contracts. Cleaned up old command definitions for consistency and maintainability.

closes #622 