### PR TITLE
Refactor: Move operator queries to OperatorQueries class

### DIFF
--- a/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
@@ -35,7 +35,7 @@ public class EstateIndexPageTests : BaseTest
             .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
         _mockMediator.Setup(x => x.Send(It.IsAny<EstateQueries.GetAssignedOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
 
         // Act
@@ -65,7 +65,7 @@ public class EstateIndexPageTests : BaseTest
             .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
         _mockMediator.Setup(x => x.Send(It.IsAny<EstateQueries.GetAssignedOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
 
         // Act
@@ -87,7 +87,7 @@ public class EstateIndexPageTests : BaseTest
             .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
         _mockMediator.Setup(x => x.Send(It.IsAny<EstateQueries.GetAssignedOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
 
         // Act

--- a/EstateManagementUI.BlazorServer.Tests/Pages/Operators/OperatorsIndexPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Operators/OperatorsIndexPageTests.cs
@@ -31,7 +31,7 @@ public class OperatorsIndexPageTests : BaseTest
             }
         };
         
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(operators));
         
         // Act
@@ -46,7 +46,7 @@ public class OperatorsIndexPageTests : BaseTest
     {
         // Arrange
         var emptyList = new List<OperatorModel>();
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(emptyList));
         
         // Act
@@ -79,7 +79,7 @@ public class OperatorsIndexPageTests : BaseTest
             }
         };
         
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(operators));
         
         // Act
@@ -106,7 +106,7 @@ public class OperatorsIndexPageTests : BaseTest
             }
         };
         
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(operators));
         
         // Act
@@ -122,7 +122,7 @@ public class OperatorsIndexPageTests : BaseTest
     public void OperatorsIndex_HasCorrectPageTitle()
     {
         // Arrange
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorsQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
         
         // Act

--- a/EstateManagementUI.BlazorServer.Tests/Pages/Operators/OperatorsViewPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Operators/OperatorsViewPageTests.cs
@@ -26,7 +26,7 @@ public class OperatorsViewPageTests : BaseTest
             Name = "Test Operator"
         };
         
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorQuery>(), default))
             .ReturnsAsync(Result.Success(operatorModel));
         
         // Act
@@ -48,7 +48,7 @@ public class OperatorsViewPageTests : BaseTest
             Name = "Test Operator"
         };
         
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorQuery>(), default))
             .ReturnsAsync(Result.Success(operatorModel));
         
         // Act
@@ -65,7 +65,7 @@ public class OperatorsViewPageTests : BaseTest
     {
         // Arrange
         var operatorId = Guid.NewGuid();
-        _mockMediator.Setup(x => x.Send(It.IsAny<Queries.GetOperatorQuery>(), default))
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorQuery>(), default))
             .ReturnsAsync(Result.Success(new OperatorModel { OperatorId = operatorId }));
         
         // Act

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/New.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/New.razor
@@ -136,7 +136,7 @@ else
         try
         {
             isLoadingOperators = true;
-            var result = await Mediator.Send(new Queries.GetOperatorsQuery(CorrelationIdHelper.New(), Guid.Parse("11111111-1111-1111-1111-111111111111")));
+            var result = await Mediator.Send(new OperatorQueries.GetOperatorsQuery(CorrelationIdHelper.New(), Guid.Parse("11111111-1111-1111-1111-111111111111")));
             if (result.IsSuccess)
             {
                 operators = ModelFactory.ConvertFrom(result.Data);

--- a/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor.cs
@@ -54,7 +54,7 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Estate
             Task<Result<List<BusinessLogic.Models.RecentMerchantsModel>>> merchantTask = Mediator.Send(new MerchantQueries.GetRecentMerchantsQuery(correlationId, estateId));
             Task<Result<List<BusinessLogic.Models.RecentContractModel>>> contractsTask = Mediator.Send(new ContractQueries.GetRecentContractsQuery(correlationId, estateId));
             Task<Result<List<BusinessLogic.Models.OperatorModel>>> assignedOperatorsTask = Mediator.Send(new EstateQueries.GetAssignedOperatorsQuery(correlationId, estateId));
-            Task<Result<List<BusinessLogic.Models.OperatorModel>>> allOperatorsTask= Mediator.Send(new Queries.GetOperatorsQuery(correlationId, estateId));
+            Task<Result<List<BusinessLogic.Models.OperatorModel>>> allOperatorsTask= Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
 
             await Task.WhenAll(estateTask, merchantTask, contractsTask, assignedOperatorsTask, allOperatorsTask);
             

--- a/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor.cs
@@ -150,7 +150,7 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Merchants
             var correlationId = new CorrelationId(Guid.NewGuid());
             var estateId = await this.GetEstateId();
 
-            var result = await Mediator.Send(new Queries.GetOperatorsQuery(correlationId, estateId));
+            var result = await Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
 
             if (result.IsFailed) {
                 return ResultHelpers.CreateFailure(result);

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/Edit.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/Edit.razor
@@ -161,7 +161,7 @@ else
             var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
             var accessToken = "stubbed-token";
 
-            var result = await Mediator.Send(new Queries.GetOperatorQuery(correlationId, accessToken, estateId, OperatorId));
+            var result = await Mediator.Send(new OperatorQueries.GetOperatorQuery(correlationId, accessToken, estateId, OperatorId));
             
             if (result.IsSuccess && result.Data != null)
             {

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/Index.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/Index.razor
@@ -113,28 +113,5 @@
 </div>
 
 @code {
-    private bool isLoading = true;
-    private List<OperatorModel> operators;
-
-    protected override async Task OnInitializedAsync()
-    {
-        try
-        {
-            await RequirePermission(PermissionSection.Operator, PermissionFunction.List);
-
-            var correlationId = new CorrelationId(Guid.NewGuid());
-            var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-            var accessToken = "stubbed-token";
-
-            var result = await Mediator.Send(new Queries.GetOperatorsQuery(correlationId, estateId));
-            if (result.IsSuccess)
-            {
-                operators = ModelFactory.ConvertFrom(result.Data);
-            }
-        }
-        finally
-        {
-            isLoading = false;
-        }
-    }
+    
 }

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/Index.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/Index.razor.cs
@@ -1,0 +1,40 @@
+﻿using EstateManagementUI.BlazorServer.Factories;
+using EstateManagementUI.BlazorServer.Models;
+using EstateManagementUI.BlazorServer.Permissions;
+using EstateManagementUI.BusinessLogic.Requests;
+
+namespace EstateManagementUI.BlazorServer.Components.Pages.Operators
+{
+    public partial class Index
+    {
+        private bool isLoading = true;
+        private List<OperatorModel> operators;
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (!firstRender)
+            {
+                await base.OnAfterRenderAsync(firstRender);
+                return;
+            }
+
+            try {
+                await RequirePermission(PermissionSection.Operator, PermissionFunction.List);
+
+                var correlationId = new CorrelationId(Guid.NewGuid());
+                var estateId = await this.GetEstateId();
+
+                var result = await Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
+                if (result.IsSuccess)
+                {
+                    operators = ModelFactory.ConvertFrom(result.Data);
+                }
+            }
+            finally
+            {
+                isLoading = false;
+                this.StateHasChanged();
+            }
+        }
+    }
+}

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/View.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/View.razor
@@ -98,7 +98,7 @@
             var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
             var accessToken = "stubbed-token";
 
-            var result = await Mediator.Send(new Queries.GetOperatorQuery(correlationId, accessToken, estateId, OperatorId));
+            var result = await Mediator.Send(new OperatorQueries.GetOperatorQuery(correlationId, accessToken, estateId, OperatorId));
             
             if (result.IsSuccess && result.Data != null)
             {

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
@@ -433,7 +433,7 @@
             
             // Load filter options
             var merchantsTask = Mediator.Send(new MerchantQueries.GetMerchantsForDropDownQuery(correlationId, estateId));
-            var operatorsTask = Mediator.Send(new Queries.GetOperatorsQuery(correlationId, estateId));
+            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
             var contractsTask = Mediator.Send(new ContractQueries.GetContractsQuery(correlationId, accessToken, estateId));
             
             await Task.WhenAll(merchantsTask, operatorsTask, contractsTask);

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryMerchant.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryMerchant.razor
@@ -277,7 +277,7 @@
             
             // Load filter options
             var merchantsTask = Mediator.Send(new MerchantQueries.GetMerchantsForDropDownQuery(correlationId, estateId));
-            var operatorsTask = Mediator.Send(new Queries.GetOperatorsQuery(correlationId, estateId));
+            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
             
             await Task.WhenAll(merchantsTask, operatorsTask);
             

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryOperator.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryOperator.razor
@@ -285,7 +285,7 @@
             
             // Load filter options
             var merchantsTask = Mediator.Send(new MerchantQueries.GetMerchantsForDropDownQuery(correlationId, estateId));
-            var operatorsTask = Mediator.Send(new Queries.GetOperatorsQuery(correlationId, estateId));
+            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
             
             await Task.WhenAll(merchantsTask, operatorsTask);
             

--- a/EstateManagmentUI.BusinessLogic/Client/OperatorMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/OperatorMethods.cs
@@ -10,12 +10,12 @@ namespace EstateManagementUI.BusinessLogic.Client
 {
     public partial interface IApiClient
     {
-        Task<Result<List<OperatorModel>>> GetOperators(Queries.GetOperatorsQuery request,
+        Task<Result<List<OperatorModel>>> GetOperators(OperatorQueries.GetOperatorsQuery request,
                                                                      CancellationToken cancellationToken);
     }
 
     public partial class ApiClient : IApiClient {
-        public async Task<Result<List<OperatorModel>>> GetOperators(Queries.GetOperatorsQuery request,
+        public async Task<Result<List<OperatorModel>>> GetOperators(OperatorQueries.GetOperatorsQuery request,
                                                                     CancellationToken cancellationToken) {
             // Get a token here 
             var token = await this.GetToken(cancellationToken);

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -222,8 +222,8 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
         }
     }
 
-    public class OperatorRequestHandler : IRequestHandler<Queries.GetOperatorsQuery, Result<List<OperatorModel>>>,
-                                            IRequestHandler<Queries.GetOperatorQuery, Result<OperatorModel>>,
+    public class OperatorRequestHandler : IRequestHandler<OperatorQueries.GetOperatorsQuery, Result<List<OperatorModel>>>,
+                                            IRequestHandler<OperatorQueries.GetOperatorQuery, Result<OperatorModel>>,
                                             IRequestHandler<Commands.CreateOperatorCommand, Result>,
                                             IRequestHandler<Commands.UpdateOperatorCommand, Result>
     {
@@ -234,11 +234,11 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
             this.ApiClient = apiClient;
         }
 
-        public async Task<Result<List<OperatorModel>>> Handle(Queries.GetOperatorsQuery request,
+        public async Task<Result<List<OperatorModel>>> Handle(OperatorQueries.GetOperatorsQuery request,
                                                               CancellationToken cancellationToken) {
             return await this.ApiClient.GetOperators(request, cancellationToken);
         }
-        public async Task<Result<OperatorModel>> Handle(Queries.GetOperatorQuery request,
+        public async Task<Result<OperatorModel>> Handle(OperatorQueries.GetOperatorQuery request,
                                                         CancellationToken cancellationToken) {
             return Result.Success(StubTestData.GetMockOperator());
         }

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -34,13 +34,13 @@ public static class ContractQueries {
     public record GetContractQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid ContractId) : IRequest<Result<ContractModel>>;
 }
 
+public class OperatorQueries {
+    public record GetOperatorsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<OperatorModel>>>;
+    public record GetOperatorQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid OperatorId) : IRequest<Result<OperatorModel>>;
+}
+
 public static class Queries
 {
-    
-    public record GetOperatorsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<OperatorModel>>>;
-    
-    public record GetOperatorQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid OperatorId) : IRequest<Result<OperatorModel>>;
-    
     public record GetFileImportLogsListQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, DateTime StartDate, DateTime EndDate)
         : IRequest<Result<List<FileImportLogModel>>>;
     public record GetFileImportLogQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, Guid FileImportLogId)

--- a/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
+++ b/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
@@ -32,8 +32,8 @@ public class TestMediatorService : IMediator
             MerchantQueries.GetRecentMerchantsQuery query => Task.FromResult((TResponse)(object)Result.Success(this._testDataStore.GetRecentMerchants(query.EstateId))),
 
             // Operator Queries
-            Queries.GetOperatorsQuery query => Task.FromResult((TResponse)(object)Result.Success(this._testDataStore.GetOperators(query.EstateId))),
-            Queries.GetOperatorQuery query => Task.FromResult((TResponse)(object)this.GetOperatorResult(query.EstateId, query.OperatorId)),
+            OperatorQueries.GetOperatorsQuery query => Task.FromResult((TResponse)(object)Result.Success(this._testDataStore.GetOperators(query.EstateId))),
+            OperatorQueries.GetOperatorQuery query => Task.FromResult((TResponse)(object)this.GetOperatorResult(query.EstateId, query.OperatorId)),
 
             // Contract Queries
             ContractQueries.GetContractsQuery query => Task.FromResult((TResponse)(object)Result.Success(this._testDataStore.GetContracts(query.EstateId))),


### PR DESCRIPTION
Operator-related queries (GetOperatorsQuery, GetOperatorQuery) have been moved from the generic Queries class to a new OperatorQueries class. All usages across the codebase—including Blazor components, request handlers, API client, and tests—have been updated accordingly. The Operators Index page's data loading logic was moved to a new partial class. This improves code organization and maintainability by grouping operator-specific queries together.