### PR TITLE
Refactor operator creation to use new command structure

### DIFF
--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/New.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/New.razor
@@ -29,6 +29,14 @@
             <p class="text-sm">@errorMessage</p>
         </div>
     }
+    
+    @if (!string.IsNullOrWhiteSpace(successMessage))
+    {
+        <div class="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg">
+            <p class="font-medium">Success</p>
+            <p class="text-sm">@successMessage</p>
+        </div>
+    }
 
     <!-- Form -->
     <div class="bg-white rounded-lg shadow-md p-6">
@@ -85,71 +93,3 @@
         </EditForm>
     </div>
 </div>
-
-@code {
-    private CreateOperatorModel model = new();
-    private bool isSaving = false;
-    private string? errorMessage;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await RequirePermission(PermissionSection.Operator, PermissionFunction.Create);
-    }
-
-    private async Task HandleSubmit()
-    {
-        isSaving = true;
-        errorMessage = null;
-
-        try
-        {
-            var correlationId = new CorrelationId(Guid.NewGuid());
-            var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-            var accessToken = "stubbed-token";
-
-            // Create operator
-            var createCommand = new Commands.CreateOperatorCommand(
-                correlationId,
-                accessToken,
-                estateId,
-                model.OperatorName!,
-                model.RequireCustomMerchantNumber,
-                model.RequireCustomTerminalNumber
-            );
-
-            var createResult = await Mediator.Send(createCommand);
-
-            if (!createResult.IsSuccess)
-            {
-                errorMessage = createResult.Message ?? "Failed to create operator";
-                return;
-            }
-
-            // Navigate to operators list with success
-            NavigationManager.NavigateTo("/operators");
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"An error occurred: {ex.Message}";
-        }
-        finally
-        {
-            isSaving = false;
-        }
-    }
-
-    private void Cancel()
-    {
-        NavigationManager.NavigateTo("/operators");
-    }
-
-    public class CreateOperatorModel
-    {
-        [Required(ErrorMessage = "Operator name is required")]
-        public string? OperatorName { get; set; }
-
-        public bool RequireCustomMerchantNumber { get; set; }
-
-        public bool RequireCustomTerminalNumber { get; set; }
-    }
-}

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/New.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/New.razor.cs
@@ -1,0 +1,88 @@
+﻿using EstateManagementUI.BlazorServer.Permissions;
+using EstateManagementUI.BusinessLogic.Requests;
+using System.ComponentModel.DataAnnotations;
+
+namespace EstateManagementUI.BlazorServer.Components.Pages.Operators
+{
+    public partial class New
+    {
+        private CreateOperatorModel model = new();
+        private bool isSaving = false;
+        private string? errorMessage;
+        private string? successMessage;
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (!firstRender)
+            {
+                await base.OnAfterRenderAsync(firstRender);
+                return;
+            }
+
+            await RequirePermission(PermissionSection.Operator, PermissionFunction.Create);
+        }
+
+        private async Task HandleSubmit()
+        {
+            isSaving = true;
+            errorMessage = null;
+
+            try
+            {
+                var correlationId = new CorrelationId(Guid.NewGuid());
+                var estateId = await this.GetEstateId();
+
+                // Create operator
+                var createCommand = new OperatorCommands.CreateOperatorCommand(
+                    correlationId,
+                    estateId,
+                    model.OperatorName!,
+                    model.RequireCustomMerchantNumber,
+                    model.RequireCustomTerminalNumber
+                );
+
+                var createResult = await Mediator.Send(createCommand);
+
+                if (!createResult.IsSuccess)
+                {
+                    errorMessage = createResult.Message ?? "Failed to create operator";
+                    return;
+                }
+
+                // Show success message briefly before navigating away
+                successMessage = "Operator created successfully.";
+                StateHasChanged();
+
+                // Small delay so user sees confirmation (adjust duration as needed)
+                await Task.Delay(2500);
+
+
+                // Navigate to operators list with success
+                NavigationManager.NavigateTo("/operators");
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"An error occurred: {ex.Message}";
+            }
+            finally
+            {
+                isSaving = false;
+            }
+        }
+
+        private void Cancel()
+        {
+            NavigationManager.NavigateTo("/operators");
+        }
+
+        public class CreateOperatorModel
+        {
+            [Required(ErrorMessage = "Operator name is required")]
+            public string? OperatorName { get; set; }
+
+            public bool RequireCustomMerchantNumber { get; set; }
+
+            public bool RequireCustomTerminalNumber { get; set; }
+        }
+    }
+}

--- a/EstateManagmentUI.BusinessLogic/Client/OperatorMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/OperatorMethods.cs
@@ -19,6 +19,9 @@ namespace EstateManagementUI.BusinessLogic.Client
 
         Task<Result> UpdateOperator(OperatorCommands.UpdateOperatorCommand request,
                                                 CancellationToken cancellationToken);
+
+        Task<Result> CreateOperator(OperatorCommands.CreateOperatorCommand request,
+                                    CancellationToken cancellationToken);
     }
 
     public partial class ApiClient : IApiClient {
@@ -66,6 +69,22 @@ namespace EstateManagementUI.BusinessLogic.Client
             var apiRequest = new UpdateOperatorRequest() { Name= request.Name, RequireCustomMerchantNumber = request.RequireCustomMerchantNumber, RequireCustomTerminalNumber = request.RequireCustomTerminalNumber};
 
             var apiResult = await this.TransactionProcessorClient.UpdateOperator(token.Data, request.EstateId, request.OperatorId, apiRequest, cancellationToken);
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            return Result.Success();
+        }
+
+        public async Task<Result> CreateOperator(OperatorCommands.CreateOperatorCommand request,
+                                                 CancellationToken cancellationToken)
+        {
+            var token = await this.GetToken(cancellationToken);
+            if (token.IsFailed)
+                return ResultHelpers.CreateFailure(token);
+
+            var apiRequest = new CreateOperatorRequest() { Name = request.Name, RequireCustomMerchantNumber = request.RequireCustomMerchantNumber, RequireCustomTerminalNumber = request.RequireCustomTerminalNumber };
+
+            var apiResult = await this.TransactionProcessorClient.CreateOperator(token.Data, request.EstateId, apiRequest, cancellationToken);
             if (apiResult.IsFailed)
                 return ResultHelpers.CreateFailure(apiResult);
 

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -224,7 +224,7 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
 
     public class OperatorRequestHandler : IRequestHandler<OperatorQueries.GetOperatorsQuery, Result<List<OperatorModel>>>,
                                             IRequestHandler<OperatorQueries.GetOperatorQuery, Result<OperatorModel>>,
-                                            IRequestHandler<Commands.CreateOperatorCommand, Result>,
+                                            IRequestHandler<OperatorCommands.CreateOperatorCommand, Result>,
                                             IRequestHandler<OperatorCommands.UpdateOperatorCommand, Result>
     {
         private readonly IApiClient ApiClient;
@@ -242,9 +242,9 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
                                                         CancellationToken cancellationToken) {
             return await this.ApiClient.GetOperator(request, cancellationToken);
         }
-        public async Task<Result> Handle(Commands.CreateOperatorCommand request,
+        public async Task<Result> Handle(OperatorCommands.CreateOperatorCommand request,
                                          CancellationToken cancellationToken) {
-            return Result.Success();
+            return await this.ApiClient.CreateOperator(request, cancellationToken);
         }
         public async Task<Result> Handle(OperatorCommands.UpdateOperatorCommand request,
                                          CancellationToken cancellationToken) {

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -90,6 +90,8 @@ public static class MerchantCommands {
 
 public static class OperatorCommands {
     public record UpdateOperatorCommand(CorrelationId CorrelationId,Guid EstateId, Guid OperatorId, string Name, bool RequireCustomMerchantNumber, bool RequireCustomTerminalNumber) : IRequest<Result>;
+
+    public record CreateOperatorCommand(CorrelationId CorrelationId, Guid EstateId, string Name, bool RequireCustomMerchantNumber, bool RequireCustomTerminalNumber) : IRequest<Result>;
 }
 
 public static class Commands
@@ -97,7 +99,6 @@ public static class Commands
     
     public record CreateContractCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, string Description, Guid OperatorId) : IRequest<Result>;
     public record CreateMerchantUserCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid MerchantId, string EmailAddress, string Password) : IRequest<Result>;
-    public record CreateOperatorCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, string Name, bool RequireCustomMerchantNumber, bool RequireCustomTerminalNumber) : IRequest<Result>;
     
     
     

--- a/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
+++ b/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
@@ -69,7 +69,7 @@ public class TestMediatorService : IMediator
             // Commands - execute against test data store
             MerchantCommands.CreateMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteCreateMerchant(cmd)),
             MerchantCommands.UpdateMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteUpdateMerchant(cmd)),
-            Commands.CreateOperatorCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteCreateOperator(cmd)),
+            OperatorCommands.CreateOperatorCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteCreateOperator(cmd)),
             OperatorCommands.UpdateOperatorCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteUpdateOperator(cmd)),
             Commands.CreateContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteCreateContract(cmd)),
             Commands.AddProductToContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddProductToContract(cmd)),
@@ -170,7 +170,7 @@ public class TestMediatorService : IMediator
         return Result.Success();
     }
     
-    private Result ExecuteCreateOperator(Commands.CreateOperatorCommand cmd)
+    private Result ExecuteCreateOperator(OperatorCommands.CreateOperatorCommand cmd)
     {
         var operatorModel = new OperatorModel
         {


### PR DESCRIPTION
Refactored operator creation to use OperatorCommands.CreateOperatorCommand instead of the obsolete Commands.CreateOperatorCommand. Updated business logic, API client, and request handler to support the new command. Moved New.razor logic to code-behind, improved user feedback with success messages, and updated UI to display both error and success states. Updated test mediator for compatibility. Removed obsolete command from Commands class.

closes #638 