### PR TITLE
Refactor contract data loading and model structure

### DIFF
--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Index.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Index.razor
@@ -88,25 +88,3 @@
         </div>
     }
 </div>
-
-@code {
-    private bool isLoading = true;
-    private List<ContractModel>? contracts;
-
-    protected override async Task OnInitializedAsync()
-    {
-        try
-        {
-            await RequirePermission(PermissionSection.Contract, PermissionFunction.List);
-
-            var result = await Mediator.Send(new ContractQueries.GetContractsQuery(CorrelationIdHelper.New(), "stubbed-token", Guid.Parse("11111111-1111-1111-1111-111111111111")));
-            if (result.IsSuccess) {
-                contracts = ModelFactory.ConvertFrom(result.Data);
-            }
-        }
-        finally
-        {
-            isLoading = false;
-        }
-    }
-}

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Index.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Index.razor.cs
@@ -1,0 +1,38 @@
+﻿using EstateManagementUI.BlazorServer.Factories;
+using EstateManagementUI.BlazorServer.Models;
+using EstateManagementUI.BlazorServer.Permissions;
+using EstateManagementUI.BusinessLogic.Requests;
+
+namespace EstateManagementUI.BlazorServer.Components.Pages.Contracts
+{
+    public partial class Index
+    {
+        private bool isLoading = true;
+        private List<ContractModel>? contracts;
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (!firstRender)
+            {
+                await base.OnAfterRenderAsync(firstRender);
+                return;
+            }
+
+            try
+            {
+                await RequirePermission(PermissionSection.Contract, PermissionFunction.List);
+                var estateId = await this.GetEstateId();
+                var result = await Mediator.Send(new ContractQueries.GetContractsQuery(CorrelationIdHelper.New(), estateId));
+                if (result.IsSuccess)
+                {
+                    contracts = ModelFactory.ConvertFrom(result.Data);
+                }
+            }
+            finally
+            {
+                isLoading = false;
+                this.StateHasChanged();
+            }
+        }
+    }
+}

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
@@ -434,7 +434,7 @@
             // Load filter options
             var merchantsTask = Mediator.Send(new MerchantQueries.GetMerchantsForDropDownQuery(correlationId, estateId));
             var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
-            var contractsTask = Mediator.Send(new ContractQueries.GetContractsQuery(correlationId, accessToken, estateId));
+            var contractsTask = Mediator.Send(new ContractQueries.GetContractsQuery(correlationId, estateId));
             
             await Task.WhenAll(merchantsTask, operatorsTask, contractsTask);
             

--- a/EstateManagementUI.BlazorServer/Models/Models.cs
+++ b/EstateManagementUI.BlazorServer/Models/Models.cs
@@ -108,8 +108,8 @@ public class ContractProductTransactionFeeModel
 {
     public Guid TransactionFeeId { get; set; }
     public string? Description { get; set; }
-    public string? CalculationType { get; set; }
-    public string? FeeType { get; set; }
+    public Int32 CalculationType { get; set; }
+    public Int32 FeeType { get; set; }
     public decimal Value { get; set; }
 }
 

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/DataTransferObjects.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/DataTransferObjects.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
 
 namespace EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects
 {
@@ -100,7 +101,42 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects
         [JsonProperty("operator_reporting_id")]
         public Int32 OperatorReportingId { get; set; }
 
+        [JsonProperty("products")]
+        public List<ContractProduct> Products { get; set; }
+
         #endregion
+    }
+
+    public class ContractProduct
+    {
+        [JsonProperty("contract_id")]
+        public Guid ContractId { get; set; }
+        [JsonProperty("product_id")]
+        public Guid ProductId { get; set; }
+        [JsonProperty("product_name")]
+        public String ProductName { get; set; }
+        [JsonProperty("display_text")]
+        public String DisplayText { get; set; }
+        [JsonProperty("product_type")]
+        public Int32 ProductType { get; set; }
+        [JsonProperty("value")]
+        public Decimal? Value { get; set; }
+        [JsonProperty("transaction_fees")]
+        public List<ContractProductTransactionFee> TransactionFees { get; set; }
+    }
+
+    public class ContractProductTransactionFee
+    {
+        [JsonProperty("transaction_fee_id")] 
+        public Guid TransactionFeeId { get; set; }
+        [JsonProperty("description")] 
+        public string? Description { get; set; }
+        [JsonProperty("calculation_type")] 
+        public Int32 CalculationType { get; set; }
+        [JsonProperty("fee_type")] 
+        public Int32 FeeType { get; set; }
+        [JsonProperty("value")] 
+        public Decimal Value { get; set; }
     }
 
     public class Estate

--- a/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
@@ -3,6 +3,7 @@ using EstateManagementUI.BusinessLogic.Models;
 using TransactionProcessor.DataTransferObjects.Responses.Contract;
 using TransactionProcessor.DataTransferObjects.Responses.Estate;
 using TransactionProcessor.DataTransferObjects.Responses.Merchant;
+using ContractProductTransactionFee = EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects.ContractProductTransactionFee;
 
 namespace EstateManagementUI.BusinessLogic.Client;
 
@@ -318,6 +319,51 @@ public  static class FactoryExtensions{
                 Description = contract.Description,
                 OperatorName = contract.OperatorName
             };
+            contracts.Add(c);
+        }
+
+        return contracts;
+    }
+
+    public static List<ContractModel> ToContract(this List<Contract> apiResultData)
+    {
+        List<ContractModel> contracts = new();
+
+        foreach (Contract contract in apiResultData)
+        {
+            var c = new ContractModel
+            {
+                ContractId = contract.ContractId,
+                Description = contract.Description,
+                OperatorName = contract.OperatorName,
+                OperatorId = contract.OperatorId,
+                Products = new List<ContractProductModel>()
+            };
+
+            foreach (var contractProduct in contract.Products) {
+                var cp = new ContractProductModel {
+                    ProductType = ((ProductType)contractProduct.ProductType).ToString(),
+                    Value = contractProduct.Value.HasValue ? contractProduct.Value.Value.ToString("F2") : "Variable",
+                    DisplayText = contractProduct.DisplayText,
+                    ProductName = contractProduct.ProductName,
+                    ContractProductId = contractProduct.ProductId,
+                    NumberOfFees = contractProduct.TransactionFees.Count,
+                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                };
+
+                foreach (ContractProductTransactionFee contractProductTransactionFee in contractProduct.TransactionFees) {
+                    cp.TransactionFees.Add(new ContractProductTransactionFeeModel {
+                        Value = contractProductTransactionFee.Value,
+                        Description = contractProductTransactionFee.Description,
+                        CalculationType = contractProductTransactionFee.CalculationType,
+                        FeeType = contractProductTransactionFee.FeeType,
+                        TransactionFeeId = contractProductTransactionFee.TransactionFeeId
+                    });
+                }
+
+                c.Products.Add(cp);
+            }
+
             contracts.Add(c);
         }
 

--- a/EstateManagmentUI.BusinessLogic/Client/ContractMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/ContractMethods.cs
@@ -14,6 +14,8 @@ namespace EstateManagementUI.BusinessLogic.Client {
 
         Task<Result<List<ContractDropDownModel>>> GetContracts(ContractQueries.GetContractsForDropDownQuery request,
                                                                CancellationToken cancellationToken);
+        Task<Result<List<ContractModel>>> GetContracts(ContractQueries.GetContractsQuery request,
+                                                               CancellationToken cancellationToken);
     }
 
     public partial class ApiClient : IApiClient {
@@ -46,6 +48,23 @@ namespace EstateManagementUI.BusinessLogic.Client {
                 return ResultHelpers.CreateFailure(apiResult);
 
             List<ContractDropDownModel> contractModels = apiResult.Data.ToContractDropDown();
+
+            return Result.Success(contractModels);
+        }
+
+        public async Task<Result<List<ContractModel>>> GetContracts(ContractQueries.GetContractsQuery request,
+                                                                            CancellationToken cancellationToken)
+        {
+            Result<String> token = await this.GetToken(cancellationToken);
+            if (token.IsFailed)
+                return ResultHelpers.CreateFailure(token);
+
+            Result<List<Contract>> apiResult = await this.EstateReportingApiClient.GetContracts(token.Data, request.EstateId, cancellationToken);
+
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            List<ContractModel> contractModels = apiResult.Data.ToContract();
 
             return Result.Success(contractModels);
         }

--- a/EstateManagmentUI.BusinessLogic/Client/StubTestData.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/StubTestData.cs
@@ -275,16 +275,16 @@ public static class StubTestData {
                     {
                         TransactionFeeId = Guid.Parse("66666666-6666-6666-6666-666666666666"),
                         Description = "Merchant Commission",
-                        CalculationType = "Fixed",
-                        FeeType = "Merchant",
+                        CalculationType = 0,
+                        FeeType = 0,
                         Value = 0.50m
                     },
                     new ContractProductTransactionFeeModel
                     {
                         TransactionFeeId = Guid.Parse("77777777-7777-7777-7777-777777777777"),
                         Description = "Service Provider Fee",
-                        CalculationType = "Percentage",
-                        FeeType = "Service Provider",
+                        CalculationType = 1,
+                        FeeType = 1,
                         Value = 2.5m
                     }
                 }
@@ -303,8 +303,8 @@ public static class StubTestData {
                     {
                         TransactionFeeId = Guid.Parse("99999999-9999-9999-9999-999999999999"),
                         Description = "Transaction Fee",
-                        CalculationType = "Fixed",
-                        FeeType = "Merchant",
+                        CalculationType = 0,
+                        FeeType = 0,
                         Value = 1.00m
                     }
                 }

--- a/EstateManagmentUI.BusinessLogic/Models/Models.cs
+++ b/EstateManagmentUI.BusinessLogic/Models/Models.cs
@@ -86,8 +86,8 @@ public class ContractProductTransactionFeeModel
 {
     public Guid TransactionFeeId { get; set; }
     public string? Description { get; set; }
-    public string? CalculationType { get; set; }
-    public string? FeeType { get; set; }
+    public Int32 CalculationType { get; set; }
+    public Int32 FeeType { get; set; }
     public decimal Value { get; set; }
 }
 

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -188,7 +188,7 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
 
         public async Task<Result<List<ContractModel>>> Handle(ContractQueries.GetContractsQuery request,
                                                               CancellationToken cancellationToken) {
-            return Result.Success(StubTestData.GetMockContracts());
+            return await this.ApiClient.GetContracts(request, cancellationToken);
         }
 
         public async Task<Result<ContractModel>> Handle(ContractQueries.GetContractQuery request,

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -30,7 +30,7 @@ public static class EstateQueries {
 public static class ContractQueries {
     public record GetRecentContractsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<RecentContractModel>>>;
     public record GetContractsForDropDownQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<ContractDropDownModel>>>;
-    public record GetContractsQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId) : IRequest<Result<List<ContractModel>>>;
+    public record GetContractsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<ContractModel>>>;
     public record GetContractQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid ContractId) : IRequest<Result<ContractModel>>;
 }
 

--- a/EstateManagmentUI.BusinessLogic/Services/TestDataStore.cs
+++ b/EstateManagmentUI.BusinessLogic/Services/TestDataStore.cs
@@ -316,16 +316,16 @@ public class TestDataStore : ITestDataStore
                         {
                             TransactionFeeId = Guid.Parse("66666666-6666-6666-6666-666666666666"),
                             Description = "Merchant Commission",
-                            CalculationType = "Fixed",
-                            FeeType = "Merchant",
+                            CalculationType = 0,
+                            FeeType = 0,
                             Value = 0.50m
                         },
                         new ContractProductTransactionFeeModel
                         {
                             TransactionFeeId = Guid.Parse("77777777-7777-7777-7777-777777777777"),
                             Description = "Service Provider Fee",
-                            CalculationType = "Percentage",
-                            FeeType = "Service Provider",
+                            CalculationType = 1,
+                            FeeType = 1,
                             Value = 2.5m
                         }
                     }


### PR DESCRIPTION
- Remove AccessToken from GetContractsQuery; update all usages
- Update API client to handle token internally for contracts
- Change ContractProductTransactionFeeModel to use int enums
- Add DTOs for contract products and transaction fees
- Add model factory method to map API contracts to UI models
- Move contract list page logic to partial class and OnAfterRenderAsync
- Update all stub/test data to use new int-based fee types
- Remove obsolete code and ensure consistency with backend
closes #627 