### PR TITLE
Refactor operator dropdowns to use OperatorDropDownModel

### DIFF
--- a/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
@@ -35,8 +35,8 @@ public class EstateIndexPageTests : BaseTest
             .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
         _mockMediator.Setup(x => x.Send(It.IsAny<EstateQueries.GetAssignedOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<OperatorDropDownModel>()));
 
         // Act
         var cut = RenderComponent<EstateIndex>();
@@ -65,8 +65,8 @@ public class EstateIndexPageTests : BaseTest
             .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
         _mockMediator.Setup(x => x.Send(It.IsAny<EstateQueries.GetAssignedOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<OperatorDropDownModel>()));
 
         // Act
         var cut = RenderComponent<EstateIndex>();
@@ -87,8 +87,8 @@ public class EstateIndexPageTests : BaseTest
             .ReturnsAsync(Result.Success(new List<RecentContractModel>()));
         _mockMediator.Setup(x => x.Send(It.IsAny<EstateQueries.GetAssignedOperatorsQuery>(), default))
             .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
+        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
+            .ReturnsAsync(Result.Success(new List<OperatorDropDownModel>()));
 
         // Act
         var cut = RenderComponent<EstateIndex>();

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor
@@ -11,27 +11,6 @@
 
 <PageTitle>Edit Contract</PageTitle>
 
-@if (!hasPermission)
-{
-    <div class="flex items-center justify-center py-12">
-        <div class="bg-red-50 border border-red-200 rounded-lg p-6 max-w-md">
-            <div class="flex items-center space-x-3">
-                <svg class="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                </svg>
-                <div>
-                    <h3 class="text-lg font-semibold text-red-900">Access Denied</h3>
-                    <p class="text-sm text-red-700 mt-1">You don't have permission to edit contracts.</p>
-                </div>
-            </div>
-            <button class="btn btn-secondary mt-4 w-full" @onclick='() => NavigationManager.NavigateTo("/contracts")'>
-                Back to Contracts
-            </button>
-        </div>
-    </div>
-}
-else
-{
 <div class="space-y-6">
     @if (isLoading)
     {
@@ -415,8 +394,12 @@ else
     private string? feeErrorMessage;
     private Guid currentProductId;
 
-    protected override async Task OnInitializedAsync()
-    {
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) {
+        if (!firstRender) {
+            await base.OnAfterRenderAsync(firstRender);
+            return;
+        }
         await RequirePermission(PermissionSection.Contract, PermissionFunction.Edit);
         await LoadContract();
     }
@@ -426,7 +409,8 @@ else
         try
         {
             isLoading = true;
-            var result = await Mediator.Send(new ContractQueries.GetContractQuery(CorrelationIdHelper.New(),  Guid.Parse("11111111-1111-1111-1111-111111111111"), ContractId));
+            Guid estateId = await GetEstateId();
+            var result = await Mediator.Send(new ContractQueries.GetContractQuery(CorrelationIdHelper.New(),  estateId, ContractId));
             
             if (result.IsSuccess && result.Data != null)
             {
@@ -442,6 +426,7 @@ else
         finally
         {
             isLoading = false;
+            StateHasChanged();
         }
     }
 
@@ -662,5 +647,4 @@ else
         [Range(0.01, double.MaxValue, ErrorMessage = "Fee value must be greater than 0")]
         public decimal? FeeValue { get; set; }
     }
-}
 }

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/New.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/New.razor
@@ -11,27 +11,6 @@
 
 <PageTitle>Create New Contract</PageTitle>
 
-@if (!hasPermission)
-{
-    <div class="flex items-center justify-center py-12">
-        <div class="bg-red-50 border border-red-200 rounded-lg p-6 max-w-md">
-            <div class="flex items-center space-x-3">
-                <svg class="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                </svg>
-                <div>
-                    <h3 class="text-lg font-semibold text-red-900">Access Denied</h3>
-                    <p class="text-sm text-red-700 mt-1">You don't have permission to create contracts.</p>
-                </div>
-            </div>
-            <button class="btn btn-secondary mt-4 w-full" @onclick='() => NavigationManager.NavigateTo("/contracts")'>
-                Back to Contracts
-            </button>
-        </div>
-    </div>
-}
-else
-{
 <div class="space-y-6">
     <!-- Page Header -->
     <div class="flex items-center justify-between">
@@ -83,7 +62,7 @@ else
                                 <option value="">-- Select Operator --</option>
                                 @foreach (var op in operators)
                                 {
-                                    <option value="@op.OperatorId">@op.Name</option>
+                                    <option value="@op.OperatorId">@op.OperatorName</option>
                                 }
                             </InputSelect>
                             <ValidationMessage For="@(() => model.OperatorId)" class="text-red-600 text-sm mt-1" />
@@ -123,20 +102,25 @@ else
     private bool isLoadingOperators = true;
     private bool hasPermission = false;
     private string? errorMessage;
-    private List<OperatorModel>? operators;
+    private List<OperatorDropDownModel>? operators;
 
-    protected override async Task OnInitializedAsync()
-    {
+    protected override async Task OnAfterRenderAsync(bool firstRender) {
+        if (!firstRender) {
+            await base.OnAfterRenderAsync(firstRender);
+            return;
+        }
         await RequirePermission(PermissionSection.Contract, PermissionFunction.Create);
         await LoadOperators();
     }
+
 
     private async Task LoadOperators()
     {
         try
         {
             isLoadingOperators = true;
-            var result = await Mediator.Send(new OperatorQueries.GetOperatorsQuery(CorrelationIdHelper.New(), Guid.Parse("11111111-1111-1111-1111-111111111111")));
+            var estateId = await GetEstateId();
+            var result = await Mediator.Send(new OperatorQueries.GetOperatorsForDropDownQuery(CorrelationIdHelper.New(), estateId));
             if (result.IsSuccess)
             {
                 operators = ModelFactory.ConvertFrom(result.Data);
@@ -145,6 +129,7 @@ else
         finally
         {
             isLoadingOperators = false;
+            StateHasChanged();
         }
     }
 
@@ -201,5 +186,4 @@ else
         [Required(ErrorMessage = "Operator is required")]
         public string? OperatorId { get; set; }
     }
-}
 }

--- a/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor
@@ -208,7 +208,7 @@
                                         {
                                             @foreach (var op in availableOperators)
                                             {
-                                                <option value="@op.OperatorId">@op.Name</option>
+                                                <option value="@op.OperatorId">@op.OperatorName</option>
                                             }
                                         }
                                     </select>

--- a/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor
@@ -193,7 +193,7 @@
                                     <option value="">Select an operator...</option>
                                     @if (availableOperators != null) {
                                         @foreach (var op in availableOperators) {
-                                            <option value="@op.OperatorId">@op.Name</option>
+                                            <option value="@op.OperatorId">@op.OperatorName</option>
                                         }
                                     }
                                 </select>

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
@@ -8,6 +8,7 @@
 @using ContractProductModel = EstateManagementUI.BlazorServer.Models.ContractProductModel
 @using MerchantDropDownModel = EstateManagementUI.BlazorServer.Models.MerchantDropDownModel
 @using MerchantModel = EstateManagementUI.BlazorServer.Models.MerchantModel
+@using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorDropDownModel
 @using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModel
 @using TransactionDetailModel = EstateManagementUI.BlazorServer.Models.TransactionDetailModel
 @inject IMediator Mediator
@@ -91,12 +92,12 @@
                     <!-- Operator Filter -->
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-2">Operator</label>
-                        <MultiSelectDropdown TItem="OperatorModel"
+                        <MultiSelectDropdown TItem="OperatorDropDownModel"
                                            Items="operators"
                                            SelectedItems="_selectedOperatorIds"
                                            SelectedItemsChanged="OnOperatorSelectionChanged"
                                            GetItemId="o => o.OperatorId.ToString()"
-                                           GetItemText="o => o.Name ?? string.Empty"
+                                           GetItemText="o => o.OperatorName ?? string.Empty"
                                            Placeholder="All Operators"
                                            AriaLabel="Select one or more operators" />
                     </div>
@@ -338,7 +339,7 @@
     // Data
     private List<TransactionDetailModel>? detailData;
     private List<MerchantDropDownModel>? merchants;
-    private List<OperatorModel>? operators;
+    private List<OperatorDropDownModel>? operators;
     private List<ContractProductModel>? products;
     
     // KPIs
@@ -433,7 +434,7 @@
             
             // Load filter options
             var merchantsTask = Mediator.Send(new MerchantQueries.GetMerchantsForDropDownQuery(correlationId, estateId));
-            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
+            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsForDropDownQuery(correlationId, estateId));
             var contractsTask = Mediator.Send(new ContractQueries.GetContractsQuery(correlationId, estateId));
             
             await Task.WhenAll(merchantsTask, operatorsTask, contractsTask);

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryMerchant.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryMerchant.razor
@@ -4,6 +4,7 @@
 @using EstateManagementUI.BusinessLogic.Requests
 @using MerchantDropDownModel = EstateManagementUI.BlazorServer.Models.MerchantDropDownModel
 @using MerchantTransactionSummaryModel = EstateManagementUI.BlazorServer.Models.MerchantTransactionSummaryModel
+@using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorDropDownModel
 @using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModel
 @rendermode InteractiveServer
 @inject IMediator Mediator
@@ -94,7 +95,7 @@
                             {
                                 @foreach (var op in operators)
                                 {
-                                    <option value="@op.OperatorId">@op.Name</option>
+                                    <option value="@op.OperatorId">@op.OperatorName</option>
                                 }
                             }
                         </select>
@@ -250,7 +251,7 @@
     // Data
     private List<MerchantTransactionSummaryModel>? summaryData;
     private List<MerchantDropDownModel>? merchants;
-    private List<OperatorModel>? operators;
+    private List<OperatorDropDownModel>? operators;
     
     // KPIs
     private int totalMerchants = 0;
@@ -277,7 +278,7 @@
             
             // Load filter options
             var merchantsTask = Mediator.Send(new MerchantQueries.GetMerchantsForDropDownQuery(correlationId, estateId));
-            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
+            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsForDropDownQuery(correlationId, estateId));
             
             await Task.WhenAll(merchantsTask, operatorsTask);
             

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryOperator.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryOperator.razor
@@ -3,6 +3,7 @@
 @using EstateManagementUI.BusinessLogic.Models
 @using EstateManagementUI.BusinessLogic.Requests
 @using MerchantDropDownModel = EstateManagementUI.BlazorServer.Models.MerchantDropDownModel
+@using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorDropDownModel
 @using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModel
 @using OperatorTransactionSummaryModel = EstateManagementUI.BlazorServer.Models.OperatorTransactionSummaryModel
 @rendermode InteractiveServer
@@ -94,7 +95,7 @@
                             {
                                 @foreach (var op in operators)
                                 {
-                                    <option value="@op.OperatorId">@op.Name</option>
+                                    <option value="@op.OperatorId">@op.OperatorName</option>
                                 }
                             }
                         </select>
@@ -256,7 +257,7 @@
     // Data
     private List<OperatorTransactionSummaryModel>? summaryData;
     private List<MerchantDropDownModel>? merchants;
-    private List<OperatorModel>? operators;
+    private List<OperatorDropDownModel>? operators;
     
     // KPIs
     private int totalOperators = 0;
@@ -285,7 +286,7 @@
             
             // Load filter options
             var merchantsTask = Mediator.Send(new MerchantQueries.GetMerchantsForDropDownQuery(correlationId, estateId));
-            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
+            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsForDropDownQuery(correlationId, estateId));
             
             await Task.WhenAll(merchantsTask, operatorsTask);
             

--- a/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
+++ b/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
@@ -1,6 +1,39 @@
-﻿
-using EstateManagementUI.BlazorServer.Models;
+﻿using EstateManagementUI.BusinessLogic.Models;
 using TransactionProcessor.DataTransferObjects.Responses.Contract;
+using ComparisonDateModel = EstateManagementUI.BlazorServer.Models.ComparisonDateModel;
+using ContractDropDownModel = EstateManagementUI.BlazorServer.Models.ContractDropDownModel;
+using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorDropDownModel;
+using ContractModel = EstateManagementUI.BlazorServer.Models.ContractModel;
+using ContractProductModel = EstateManagementUI.BlazorServer.Models.ContractProductModel;
+using ContractProductTransactionFeeModel = EstateManagementUI.BlazorServer.Models.ContractProductTransactionFeeModel;
+using EstateContractModel = EstateManagementUI.BlazorServer.Models.EstateContractModel;
+using EstateMerchantModel = EstateManagementUI.BlazorServer.Models.EstateMerchantModel;
+using EstateModel = EstateManagementUI.BlazorServer.Models.EstateModel;
+using EstateOperatorModel = EstateManagementUI.BlazorServer.Models.EstateOperatorModel;
+using EstateUserModel = EstateManagementUI.BlazorServer.Models.EstateUserModel;
+using FileDetailsModel = EstateManagementUI.BlazorServer.Models.FileDetailsModel;
+using FileImportLogModel = EstateManagementUI.BlazorServer.Models.FileImportLogModel;
+using MerchantContractModel = EstateManagementUI.BlazorServer.Models.MerchantContractModel;
+using MerchantContractProductModel = EstateManagementUI.BlazorServer.Models.MerchantContractProductModel;
+using MerchantDeviceModel = EstateManagementUI.BlazorServer.Models.MerchantDeviceModel;
+using MerchantDropDownModel = EstateManagementUI.BlazorServer.Models.MerchantDropDownModel;
+using MerchantKpiModel = EstateManagementUI.BlazorServer.Models.MerchantKpiModel;
+using MerchantListModel = EstateManagementUI.BlazorServer.Models.MerchantListModel;
+using MerchantModel = EstateManagementUI.BlazorServer.Models.MerchantModel;
+using MerchantOperatorModel = EstateManagementUI.BlazorServer.Models.MerchantOperatorModel;
+using MerchantSettlementHistoryModel = EstateManagementUI.BlazorServer.Models.MerchantSettlementHistoryModel;
+using MerchantTransactionSummaryModel = EstateManagementUI.BlazorServer.Models.MerchantTransactionSummaryModel;
+using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModel;
+using OperatorTransactionSummaryModel = EstateManagementUI.BlazorServer.Models.OperatorTransactionSummaryModel;
+using ProductPerformanceModel = EstateManagementUI.BlazorServer.Models.ProductPerformanceModel;
+using RecentContractModel = EstateManagementUI.BlazorServer.Models.RecentContractModel;
+using RecentMerchantsModel = EstateManagementUI.BlazorServer.Models.RecentMerchantsModel;
+using SettlementSummaryModel = EstateManagementUI.BlazorServer.Models.SettlementSummaryModel;
+using TodaysSalesCountByHourModel = EstateManagementUI.BlazorServer.Models.TodaysSalesCountByHourModel;
+using TodaysSalesModel = EstateManagementUI.BlazorServer.Models.TodaysSalesModel;
+using TodaysSalesValueByHourModel = EstateManagementUI.BlazorServer.Models.TodaysSalesValueByHourModel;
+using TodaysSettlementModel = EstateManagementUI.BlazorServer.Models.TodaysSettlementModel;
+using TransactionDetailModel = EstateManagementUI.BlazorServer.Models.TransactionDetailModel;
 
 namespace EstateManagementUI.BlazorServer.Factories {
     public static class ModelFactory {
@@ -459,6 +492,20 @@ namespace EstateManagementUI.BlazorServer.Factories {
             }
 
             return contractList;
+        }
+
+        public static List<OperatorDropDownModel>? ConvertFrom(List<BusinessLogic.Models.OperatorDropDownModel> resultData) {
+            List<OperatorDropDownModel> operatorList = new();
+            foreach (BusinessLogic.Models.OperatorDropDownModel operatorDropDownModel in resultData)
+            {
+                operatorList.Add(new OperatorDropDownModel()
+                {
+                    OperatorId = operatorDropDownModel.OperatorId,
+                    OperatorName = operatorDropDownModel.OperatorName
+                });
+            }
+
+            return operatorList;
         }
     }
 }

--- a/EstateManagementUI.BlazorServer/Models/Models.cs
+++ b/EstateManagementUI.BlazorServer/Models/Models.cs
@@ -83,6 +83,12 @@ public class ContractDropDownModel
     public string? OperatorName { get; set; }
 }
 
+public class OperatorDropDownModel
+{
+    public Guid OperatorId { get; set; }
+    public string? OperatorName { get; set; }
+}
+
 // Contract Models
 public class ContractModel
 {

--- a/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
@@ -114,10 +114,31 @@ public  static class FactoryExtensions{
         return model;
     }
 
+    public static OperatorDropDownModel ToOperatorDropDown(this Operator apiResultData)
+    {
+        OperatorDropDownModel model = new()
+        {
+            OperatorName= apiResultData.Name,
+            OperatorId = apiResultData.OperatorId
+        };
+        return model;
+    }
+
+    public static List<OperatorDropDownModel> ToOperatorDropDown(this List<Operator> apiResultData)
+    {
+        List<OperatorDropDownModel> operators = new();
+        foreach (Operator op in apiResultData) {
+            operators.Add(op.ToOperatorDropDown());
+        }
+
+        return operators;
+    }
+
     public static List<OperatorModel> ToOperator(this List<Operator> apiResultData)
     {
         List<OperatorModel> operators = new();
-        foreach (Operator op in apiResultData) {
+        foreach (Operator op in apiResultData)
+        {
             operators.Add(op.ToOperator());
         }
 

--- a/EstateManagmentUI.BusinessLogic/Client/OperatorMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/OperatorMethods.cs
@@ -14,6 +14,9 @@ namespace EstateManagementUI.BusinessLogic.Client
         Task<Result<List<OperatorModel>>> GetOperators(OperatorQueries.GetOperatorsQuery request,
                                                                      CancellationToken cancellationToken);
 
+        Task<Result<List<OperatorDropDownModel>>> GetOperators(OperatorQueries.GetOperatorsForDropDownQuery request,
+                                                       CancellationToken cancellationToken);
+
         Task<Result<OperatorModel>> GetOperator(OperatorQueries.GetOperatorQuery request,
                                                 CancellationToken cancellationToken);
 
@@ -38,6 +41,24 @@ namespace EstateManagementUI.BusinessLogic.Client
                 return ResultHelpers.CreateFailure(apiResult);
 
             List<OperatorModel> operatorModels = apiResult.Data.ToOperator();
+
+            return Result.Success(operatorModels);
+        }
+
+        public async Task<Result<List<OperatorDropDownModel>>> GetOperators(OperatorQueries.GetOperatorsForDropDownQuery request,
+                                                                    CancellationToken cancellationToken)
+        {
+            // Get a token here 
+            var token = await this.GetToken(cancellationToken);
+            if (token.IsFailed)
+                return ResultHelpers.CreateFailure(token);
+
+            var apiResult = await this.EstateReportingApiClient.GetOperators(token.Data, request.EstateId, cancellationToken);
+
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            List<OperatorDropDownModel> operatorModels = apiResult.Data.ToOperatorDropDown();
 
             return Result.Success(operatorModels);
         }

--- a/EstateManagmentUI.BusinessLogic/Models/Models.cs
+++ b/EstateManagmentUI.BusinessLogic/Models/Models.cs
@@ -44,13 +44,7 @@ public class EstateMerchantModel {
 
 
 // Operator Models
-public class OperatorModel
-{
-    public Guid OperatorId { get; set; }
-    public string? Name { get; set; }
-    public bool RequireCustomMerchantNumber { get; set; }
-    public bool RequireCustomTerminalNumber { get; set; }
-}
+
 
 // Contract Models
 public class ContractModel

--- a/EstateManagmentUI.BusinessLogic/Models/OperatorModels.cs
+++ b/EstateManagmentUI.BusinessLogic/Models/OperatorModels.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EstateManagementUI.BusinessLogic.Models
+{
+    public class OperatorModel
+    {
+        public Guid OperatorId { get; set; }
+        public string? Name { get; set; }
+        public bool RequireCustomMerchantNumber { get; set; }
+        public bool RequireCustomTerminalNumber { get; set; }
+    }
+
+    public class OperatorDropDownModel
+    {
+        public Guid OperatorId { get; set; }
+        public string? OperatorName { get; set; }
+    }
+}

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -224,6 +224,7 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
 
     public class OperatorRequestHandler : IRequestHandler<OperatorQueries.GetOperatorsQuery, Result<List<OperatorModel>>>,
                                             IRequestHandler<OperatorQueries.GetOperatorQuery, Result<OperatorModel>>,
+                                            IRequestHandler<OperatorQueries.GetOperatorsForDropDownQuery, Result<List<OperatorDropDownModel>>>,
                                             IRequestHandler<OperatorCommands.CreateOperatorCommand, Result>,
                                             IRequestHandler<OperatorCommands.UpdateOperatorCommand, Result>
     {
@@ -249,6 +250,11 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
         public async Task<Result> Handle(OperatorCommands.UpdateOperatorCommand request,
                                          CancellationToken cancellationToken) {
             return await this.ApiClient.UpdateOperator(request, cancellationToken);
+        }
+
+        public async Task<Result<List<OperatorDropDownModel>>> Handle(OperatorQueries.GetOperatorsForDropDownQuery request,
+                                                                      CancellationToken cancellationToken) {
+            return await this.ApiClient.GetOperators(request, cancellationToken);
         }
     }
 

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -37,6 +37,7 @@ public static class ContractQueries {
 public class OperatorQueries {
     public record GetOperatorsQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<OperatorModel>>>;
     public record GetOperatorQuery(CorrelationId CorrelationId, Guid EstateId, Guid OperatorId) : IRequest<Result<OperatorModel>>;
+    public record GetOperatorsForDropDownQuery(CorrelationId CorrelationId, Guid EstateId) : IRequest<Result<List<OperatorDropDownModel>>>;
 }
 
 public static class Queries


### PR DESCRIPTION
Introduce OperatorDropDownModel for dropdowns and update all UI components, queries, and API methods to use it instead of OperatorModel for selection/filtering. Add new GetOperatorsForDropDownQuery, update factories for conversion, and move full OperatorModel to BusinessLogic.Models. Improves clarity and efficiency in operator selection scenarios.

closes #629 