### PR TITLE
Refactor AddProductToContract command and API integration

### DIFF
--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor.cs
@@ -111,14 +111,11 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Contracts
             isAddingProduct = true;
             productErrorMessage = null;
 
-            try
-            {
-                var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-                var accessToken = "stubbed-token";
+            try {
+                var estateId = await this.GetEstateId();
 
-                var command = new Commands.AddProductToContractCommand(
+                var command = new ContractCommands.AddProductToContractCommand(
                     CorrelationIdHelper.New(),
-                    accessToken,
                     estateId,
                     ContractId,
                     productModel.ProductName!,
@@ -132,7 +129,14 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Contracts
                 {
                     successMessage = "Product added successfully";
                     CloseAddProductModal();
+                    
+                    // Small delay so user sees confirmation (adjust duration as needed)
+                    await Task.Delay(2500);
+
                     await LoadContract();
+
+                    StateHasChanged();
+
                 }
                 else
                 {

--- a/EstateManagmentUI.BusinessLogic/Client/ContractMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/ContractMethods.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text;
 using EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects;
 using TransactionProcessor.DataTransferObjects.Requests.Contract;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
 
 namespace EstateManagementUI.BusinessLogic.Client {
     public partial interface IApiClient {
@@ -21,6 +22,8 @@ namespace EstateManagementUI.BusinessLogic.Client {
                                                        CancellationToken cancellationToken);
 
         Task<Result> CreateContract(ContractCommands.CreateContractCommand request,
+                                    CancellationToken cancellationToken);
+        Task<Result> AddProductToContract(ContractCommands.AddProductToContractCommand request,
                                     CancellationToken cancellationToken);
     }
 
@@ -101,6 +104,21 @@ namespace EstateManagementUI.BusinessLogic.Client {
             var apiRequest = new CreateContractRequest() { Description = request.Description, OperatorId = request.OperatorId };
 
             var apiResult = await this.TransactionProcessorClient.CreateContract(token.Data, request.EstateId, apiRequest, cancellationToken);
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            return Result.Success();
+        }
+
+        public async Task<Result> AddProductToContract(ContractCommands.AddProductToContractCommand request,
+                                                       CancellationToken cancellationToken) {
+            var token = await this.GetToken(cancellationToken);
+            if (token.IsFailed)
+                return ResultHelpers.CreateFailure(token);
+
+            var apiRequest = new AddProductToContractRequest() { ProductType = ProductType.NotSet, Value = request.Value, DisplayText = request.DisplayText, ProductName = request.ProductName};
+
+            var apiResult = await this.TransactionProcessorClient.AddProductToContract(token.Data, request.EstateId, request.ContractId, apiRequest, cancellationToken);
             if (apiResult.IsFailed)
                 return ResultHelpers.CreateFailure(apiResult);
 

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -173,7 +173,7 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
     public class ContractRequestHandler : IRequestHandler<ContractQueries.GetContractsQuery, Result<List<ContractModel>>>,
                                             IRequestHandler<ContractQueries.GetContractQuery, Result<ContractModel>>,
                                             IRequestHandler<ContractCommands.CreateContractCommand, Result>,
-                                            IRequestHandler<Commands.AddProductToContractCommand, Result>,
+                                            IRequestHandler<ContractCommands.AddProductToContractCommand, Result>,
                                             IRequestHandler<Commands.AddTransactionFeeForProductToContractCommand, Result>,
     IRequestHandler<ContractQueries.GetRecentContractsQuery, Result<List<RecentContractModel>>>,
     IRequestHandler<ContractQueries.GetContractsForDropDownQuery, Result<List<ContractDropDownModel>>>
@@ -201,9 +201,9 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
             return await this.ApiClient.CreateContract(request, cancellationToken);
         }
 
-        public async Task<Result> Handle(Commands.AddProductToContractCommand request,
+        public async Task<Result> Handle(ContractCommands.AddProductToContractCommand request,
                                          CancellationToken cancellationToken) {
-            return Result.Success();
+            return await this.ApiClient.AddProductToContract(request, cancellationToken);
         }
 
         public async Task<Result> Handle(Commands.AddTransactionFeeForProductToContractCommand request,

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -97,6 +97,7 @@ public static class OperatorCommands {
 
 public static class ContractCommands {
     public record CreateContractCommand(CorrelationId CorrelationId, Guid EstateId, string Description, Guid OperatorId) : IRequest<Result>;
+    public record AddProductToContractCommand(CorrelationId CorrelationId, Guid EstateId, Guid ContractId, string ProductName, string DisplayText, decimal? Value) : IRequest<Result>;
 }
 
 public static class Commands
@@ -105,6 +106,5 @@ public static class Commands
     
     
     
-    public record AddProductToContractCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid ContractId, string ProductName, string DisplayText, decimal? Value) : IRequest<Result>;
     public record AddTransactionFeeForProductToContractCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid ContractId, Guid ProductId, string Description, decimal Value) : IRequest<Result>;
 }

--- a/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
+++ b/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
@@ -72,7 +72,7 @@ public class TestMediatorService : IMediator
             OperatorCommands.CreateOperatorCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteCreateOperator(cmd)),
             OperatorCommands.UpdateOperatorCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteUpdateOperator(cmd)),
             ContractCommands.CreateContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteCreateContract(cmd)),
-            Commands.AddProductToContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddProductToContract(cmd)),
+            ContractCommands.AddProductToContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddProductToContract(cmd)),
             Commands.AddTransactionFeeForProductToContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddTransactionFee(cmd)),
             MerchantCommands.AssignContractToMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAssignContractToMerchant(cmd)),
             MerchantCommands.RemoveContractFromMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteRemoveContractFromMerchant(cmd)),
@@ -216,7 +216,7 @@ public class TestMediatorService : IMediator
         return Result.Success();
     }
 
-    private Result ExecuteAddProductToContract(Commands.AddProductToContractCommand cmd)
+    private Result ExecuteAddProductToContract(ContractCommands.AddProductToContractCommand cmd)
     {
         var contract = this._testDataStore.GetContract(cmd.EstateId, cmd.ContractId);
         if (contract == null)


### PR DESCRIPTION
- Move AddProductToContractCommand to ContractCommands namespace and remove old definition
- Implement real AddProductToContract API client method
- Update request handler to use new command and call API client
- Update UI to use new command, fetch estate ID dynamically, and show confirmation delay
- Update test mediator to handle new command signature
- Improves separation of concerns and removes hardcoded values
closes #632 