### PR TITLE
Refactor AddTransactionFee command for contract products

### DIFF
--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor.cs
@@ -174,19 +174,18 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Contracts
             isAddingFee = true;
             feeErrorMessage = null;
 
-            try
-            {
-                var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-                var accessToken = "stubbed-token";
+            try {
+                var estateId = await this.GetEstateId();
 
-                var command = new Commands.AddTransactionFeeForProductToContractCommand(
+                var command = new ContractCommands.AddTransactionFeeForProductToContractCommand(
                     CorrelationIdHelper.New(),
-                    accessToken,
                     estateId,
                     ContractId,
                     currentProductId,
                     feeModel.Description!,
-                    feeModel.FeeValue!.Value
+                    feeModel.FeeValue!.Value,
+                    this.feeModel.CalculationType,
+                    this.feeModel.FeeType
                 );
 
                 var result = await Mediator.Send(command);
@@ -195,7 +194,13 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Contracts
                 {
                     successMessage = "Transaction fee added successfully";
                     CloseAddFeeModal();
+
+                    // Small delay so user sees confirmation (adjust duration as needed)
+                    await Task.Delay(2500);
+
                     await LoadContract();
+
+                    StateHasChanged();
                 }
                 else
                 {

--- a/EstateManagmentUI.BusinessLogic/Client/ContractMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/ContractMethods.cs
@@ -25,6 +25,8 @@ namespace EstateManagementUI.BusinessLogic.Client {
                                     CancellationToken cancellationToken);
         Task<Result> AddProductToContract(ContractCommands.AddProductToContractCommand request,
                                     CancellationToken cancellationToken);
+        Task<Result> AddTransactionFeeForProductToContract(ContractCommands.AddTransactionFeeForProductToContractCommand request,
+                                                           CancellationToken cancellationToken);
     }
 
     public partial class ApiClient : IApiClient {
@@ -119,6 +121,23 @@ namespace EstateManagementUI.BusinessLogic.Client {
             var apiRequest = new AddProductToContractRequest() { ProductType = ProductType.NotSet, Value = request.Value, DisplayText = request.DisplayText, ProductName = request.ProductName};
 
             var apiResult = await this.TransactionProcessorClient.AddProductToContract(token.Data, request.EstateId, request.ContractId, apiRequest, cancellationToken);
+            if (apiResult.IsFailed)
+                return ResultHelpers.CreateFailure(apiResult);
+
+            return Result.Success();
+        }
+
+        public async Task<Result> AddTransactionFeeForProductToContract(ContractCommands.AddTransactionFeeForProductToContractCommand request,
+                                                                        CancellationToken cancellationToken) {
+            var token = await this.GetToken(cancellationToken);
+            if (token.IsFailed)
+                return ResultHelpers.CreateFailure(token);
+
+            var apiRequest = new AddTransactionFeeForProductToContractRequest() { Value = request.Value, 
+                CalculationType = Enum.Parse<CalculationType>(request.CalculationType), Description = request.Description, 
+                FeeType = Enum.Parse<FeeType>(request.FeeType)};
+
+            var apiResult = await this.TransactionProcessorClient.AddTransactionFeeForProductToContract(token.Data, request.EstateId, request.ContractId, request.ProductId, apiRequest, cancellationToken);
             if (apiResult.IsFailed)
                 return ResultHelpers.CreateFailure(apiResult);
 

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/DateRequestHandler.cs
@@ -174,7 +174,7 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
                                             IRequestHandler<ContractQueries.GetContractQuery, Result<ContractModel>>,
                                             IRequestHandler<ContractCommands.CreateContractCommand, Result>,
                                             IRequestHandler<ContractCommands.AddProductToContractCommand, Result>,
-                                            IRequestHandler<Commands.AddTransactionFeeForProductToContractCommand, Result>,
+                                            IRequestHandler<ContractCommands.AddTransactionFeeForProductToContractCommand, Result>,
     IRequestHandler<ContractQueries.GetRecentContractsQuery, Result<List<RecentContractModel>>>,
     IRequestHandler<ContractQueries.GetContractsForDropDownQuery, Result<List<ContractDropDownModel>>>
     {
@@ -206,9 +206,9 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers
             return await this.ApiClient.AddProductToContract(request, cancellationToken);
         }
 
-        public async Task<Result> Handle(Commands.AddTransactionFeeForProductToContractCommand request,
+        public async Task<Result> Handle(ContractCommands.AddTransactionFeeForProductToContractCommand request,
                                          CancellationToken cancellationToken) {
-            return Result.Success();
+            return await this.ApiClient.AddTransactionFeeForProductToContract(request, cancellationToken);
         }
 
         public async Task<Result<List<RecentContractModel>>> Handle(ContractQueries.GetRecentContractsQuery request,

--- a/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Requests.cs
@@ -98,6 +98,7 @@ public static class OperatorCommands {
 public static class ContractCommands {
     public record CreateContractCommand(CorrelationId CorrelationId, Guid EstateId, string Description, Guid OperatorId) : IRequest<Result>;
     public record AddProductToContractCommand(CorrelationId CorrelationId, Guid EstateId, Guid ContractId, string ProductName, string DisplayText, decimal? Value) : IRequest<Result>;
+    public record AddTransactionFeeForProductToContractCommand(CorrelationId CorrelationId, Guid EstateId, Guid ContractId, Guid ProductId, string Description, decimal Value, String CalculationType, String FeeType) : IRequest<Result>;
 }
 
 public static class Commands
@@ -106,5 +107,4 @@ public static class Commands
     
     
     
-    public record AddTransactionFeeForProductToContractCommand(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid ContractId, Guid ProductId, string Description, decimal Value) : IRequest<Result>;
 }

--- a/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
+++ b/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
@@ -73,7 +73,7 @@ public class TestMediatorService : IMediator
             OperatorCommands.UpdateOperatorCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteUpdateOperator(cmd)),
             ContractCommands.CreateContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteCreateContract(cmd)),
             ContractCommands.AddProductToContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddProductToContract(cmd)),
-            Commands.AddTransactionFeeForProductToContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddTransactionFee(cmd)),
+            ContractCommands.AddTransactionFeeForProductToContractCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddTransactionFee(cmd)),
             MerchantCommands.AssignContractToMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAssignContractToMerchant(cmd)),
             MerchantCommands.RemoveContractFromMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteRemoveContractFromMerchant(cmd)),
             MerchantCommands.AddOperatorToMerchantCommand cmd => Task.FromResult((TResponse)(object)this.ExecuteAddOperatorToMerchant(cmd)),
@@ -237,7 +237,7 @@ public class TestMediatorService : IMediator
         return Result.Success();
     }
 
-    private Result ExecuteAddTransactionFee(Commands.AddTransactionFeeForProductToContractCommand cmd)
+    private Result ExecuteAddTransactionFee(ContractCommands.AddTransactionFeeForProductToContractCommand cmd)
     {
         var contract = this._testDataStore.GetContract(cmd.EstateId, cmd.ContractId);
         if (contract == null)


### PR DESCRIPTION
Standardize AddTransactionFeeForProductToContractCommand by moving it to ContractCommands, adding CalculationType and FeeType parameters, and updating all usages. Implement full support in API client, request handler, and test mediator. Update UI to use new command and show confirmation on success.


closes #634 