### PR TITLE
Refactor operator UI: add OperatorUIService, models

### DIFF
--- a/EstateManagementUI.BlazorServer.Tests/Pages/BaseTest.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/BaseTest.cs
@@ -21,8 +21,7 @@ public abstract class BaseTest :TestContext {
         this._mockPermissionService = new Mock<IPermissionService>();
         this._mockPermissionStore = new Mock<IPermissionStore>();
         this._fakeNavigationManager = new FakeNavigationManager();
-        this.EstateUIService = new Mock<IEstateUIService>();
-
+        
         this._mockPermissionKeyProvider.Setup(x => x.GetKey()).Returns("test-key");
         this._mockPermissionService.Setup(x => x.HasPermissionAsync(It.IsAny<PermissionSection>(), It.IsAny<PermissionFunction>())).ReturnsAsync(true);
 
@@ -34,6 +33,7 @@ public abstract class BaseTest :TestContext {
         this.Services.AddSingleton(this._mockAuthStateProvider.Object);
         this.Services.AddSingleton(this._mockPermissionStore.Object);
         this.Services.AddSingleton(this.EstateUIService.Object);
+        this.Services.AddSingleton(this.OperatorUIService.Object);
 
 
         // Add required permission components that render their children
@@ -53,8 +53,8 @@ public abstract class BaseTest :TestContext {
     protected readonly Mock<AuthenticationStateProvider> _mockAuthStateProvider;
     protected readonly Mock<IPermissionStore> _mockPermissionStore;
     protected readonly FakeNavigationManager _fakeNavigationManager;
-    protected readonly Mock<IEstateUIService> EstateUIService;
-
+    protected readonly Mock<IEstateUIService> EstateUIService = new Mock<IEstateUIService>();
+    protected readonly Mock<IOperatorUIService> OperatorUIService = new Mock<IOperatorUIService>();
     /// <summary>
     /// Minimal test double for NavigationManager.
     /// Register in DI as NavigationManager so components receive it in tests.

--- a/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Estate/EstateIndexPageTests.cs
@@ -25,8 +25,8 @@ public class EstateIndexPageTests : BaseTest
                 ContractCount = 0,
                 RecentContracts = new List<Models.RecentContractModel>(),
                 OperatorCount = 0,
-                AllOperators = new List<Models.OperatorDropDownModel>(),
-                AssignedOperators = new List<Models.OperatorModel>(),
+                AllOperators = new List<Models.OperatorModels.OperatorDropDownModel>(),
+                AssignedOperators = new List<OperatorModels.OperatorModel>(),
                 MerchantCount = 0,
                 RecentMerchants = new List<Models.RecentMerchantsModel>(),
                 UserCount = 0
@@ -51,8 +51,8 @@ public class EstateIndexPageTests : BaseTest
             ContractCount = 0,
             RecentContracts = new List<Models.RecentContractModel>(),
             OperatorCount = 0,
-            AllOperators = new List<Models.OperatorDropDownModel>(),
-            AssignedOperators = new List<Models.OperatorModel>(),
+            AllOperators = new List<Models.OperatorModels.OperatorDropDownModel>(),
+            AssignedOperators = new List<OperatorModels.OperatorModel>(),
             MerchantCount = 0,
             RecentMerchants = new List<Models.RecentMerchantsModel>(),
             UserCount = 0
@@ -76,8 +76,8 @@ public class EstateIndexPageTests : BaseTest
             ContractCount = 0,
             RecentContracts = new List<Models.RecentContractModel>(),
             OperatorCount = 0,
-            AllOperators = new List<Models.OperatorDropDownModel>(),
-            AssignedOperators = new List<Models.OperatorModel>(),
+            AllOperators = new List<Models.OperatorModels.OperatorDropDownModel>(),
+            AssignedOperators = new List<OperatorModels.OperatorModel>(),
             MerchantCount = 0,
             RecentMerchants = new List<Models.RecentMerchantsModel>(),
             UserCount = 0
@@ -135,14 +135,14 @@ public class EstateIndexPageTests : BaseTest
     {
         // Arrange
         Guid operatorId = Guid.NewGuid();
-        OperatorDropDownModel operatorToAdd = new() {
+        OperatorModels.OperatorDropDownModel operatorToAdd = new() {
             OperatorId = operatorId,
             OperatorName = "Test Operator"
         };
         
-        SetupSuccessfulDataLoadWithOperators(new List<OperatorDropDownModel> { operatorToAdd });
+        SetupSuccessfulDataLoadWithOperators(new List<OperatorModels.OperatorDropDownModel> { operatorToAdd });
         
-        OperatorModel operatorDetails = new() {
+        OperatorModels.OperatorModel operatorDetails = new() {
             OperatorId = operatorId,
             Name = "Test Operator",
             RequireCustomMerchantNumber = true,
@@ -183,12 +183,12 @@ public class EstateIndexPageTests : BaseTest
     {
         // Arrange
         Guid operatorId = Guid.NewGuid();
-        OperatorDropDownModel operatorToAdd = new() {
+        OperatorModels.OperatorDropDownModel operatorToAdd = new() {
             OperatorId = operatorId,
             OperatorName = "Test Operator"
         };
         
-        SetupSuccessfulDataLoadWithOperators(new List<OperatorDropDownModel> { operatorToAdd });
+        SetupSuccessfulDataLoadWithOperators(new List<OperatorModels.OperatorDropDownModel> { operatorToAdd });
 
         this.EstateUIService.Setup(e => e.AddOperatorToEstate(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<String>())).ReturnsAsync(Result.Failure);
 
@@ -220,14 +220,14 @@ public class EstateIndexPageTests : BaseTest
     {
         // Arrange
         Guid operatorId = Guid.NewGuid();
-        OperatorModel assignedOperator = new() {
+        OperatorModels.OperatorModel assignedOperator = new() {
             OperatorId = operatorId,
             Name = "Test Operator",
             RequireCustomMerchantNumber = true,
             RequireCustomTerminalNumber = false
         };
         
-        SetupSuccessfulDataLoadWithAssignedOperators(new List<OperatorModel> { assignedOperator });
+        SetupSuccessfulDataLoadWithAssignedOperators(new List<OperatorModels.OperatorModel> { assignedOperator });
 
         this.EstateUIService.Setup(e => e.RemoveOperatorFromEstate(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success);
 
@@ -255,14 +255,14 @@ public class EstateIndexPageTests : BaseTest
     {
         // Arrange
         Guid operatorId = Guid.NewGuid();
-        OperatorModel assignedOperator = new() {
+        OperatorModels.OperatorModel assignedOperator = new() {
             OperatorId = operatorId,
             Name = "Test Operator",
             RequireCustomMerchantNumber = true,
             RequireCustomTerminalNumber = false
         };
         
-        SetupSuccessfulDataLoadWithAssignedOperators(new List<OperatorModel> { assignedOperator });
+        SetupSuccessfulDataLoadWithAssignedOperators(new List<OperatorModels.OperatorModel> { assignedOperator });
 
         this.EstateUIService.Setup(e => e.RemoveOperatorFromEstate(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(Result.Failure(String.Empty));
 
@@ -377,14 +377,14 @@ public class EstateIndexPageTests : BaseTest
     {
         // Arrange
         Guid operatorId = Guid.NewGuid();
-        OperatorModel assignedOperator = new() {
+        OperatorModels.OperatorModel assignedOperator = new() {
             OperatorId = operatorId,
             Name = "Test Operator",
             RequireCustomMerchantNumber = true,
             RequireCustomTerminalNumber = true
         };
         
-        SetupSuccessfulDataLoadWithAssignedOperators(new List<OperatorModel> { assignedOperator });
+        SetupSuccessfulDataLoadWithAssignedOperators(new List<OperatorModels.OperatorModel> { assignedOperator });
         
         IRenderedComponent<EstateIndex> cut = RenderComponent<EstateIndex>();
         cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
@@ -424,14 +424,14 @@ public class EstateIndexPageTests : BaseTest
     {
         // Arrange
         Guid operatorId = Guid.NewGuid();
-        OperatorModel assignedOperator = new() {
+        OperatorModels.OperatorModel assignedOperator = new() {
             OperatorId = operatorId,
             Name = "Test Operator",
             RequireCustomMerchantNumber = true,
             RequireCustomTerminalNumber = false
         };
         
-        SetupSuccessfulDataLoadWithAssignedOperators(new List<OperatorModel> { assignedOperator });
+        SetupSuccessfulDataLoadWithAssignedOperators(new List<OperatorModels.OperatorModel> { assignedOperator });
 
         this.EstateUIService.Setup(e => e.RemoveOperatorFromEstate(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success);
 
@@ -462,8 +462,8 @@ public class EstateIndexPageTests : BaseTest
     // Helper methods
     private void SetupSuccessfulDataLoad(List<RecentMerchantsModel>? merchants = null,
                                          List<RecentContractModel>? contracts = null,
-                                         List<OperatorModel>? assignedOperators = null,
-                                         List<OperatorDropDownModel>? operators = null)
+                                         List<OperatorModels.OperatorModel>? assignedOperators = null,
+                                         List<OperatorModels.OperatorDropDownModel>? operators = null)
     {
         BlazorServer.Models.EstateModel estate = new(Guid.NewGuid(), "Test Estate", "EST001");
         estate = estate with
@@ -471,8 +471,8 @@ public class EstateIndexPageTests : BaseTest
             ContractCount = 5,
             RecentContracts = contracts ?? new List<RecentContractModel>(),
             OperatorCount = 3,
-            AllOperators = operators ?? new List<OperatorDropDownModel>(),
-            AssignedOperators = assignedOperators ?? new List<OperatorModel>(),
+            AllOperators = operators ?? new List<OperatorModels.OperatorDropDownModel>(),
+            AssignedOperators = assignedOperators ?? new List<OperatorModels.OperatorModel>(),
             MerchantCount = 10,
             RecentMerchants = merchants ?? new List<RecentMerchantsModel>(),
             UserCount = 2
@@ -480,10 +480,10 @@ public class EstateIndexPageTests : BaseTest
         this.EstateUIService.Setup(e => e.LoadEstate(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(estate));
     }
 
-    private void SetupSuccessfulDataLoadWithOperators(List<OperatorDropDownModel> operators)
+    private void SetupSuccessfulDataLoadWithOperators(List<OperatorModels.OperatorDropDownModel> operators)
         => SetupSuccessfulDataLoad(operators: operators);
 
-    private void SetupSuccessfulDataLoadWithAssignedOperators(List<OperatorModel> assignedOperators)
+    private void SetupSuccessfulDataLoadWithAssignedOperators(List<OperatorModels.OperatorModel> assignedOperators)
         => SetupSuccessfulDataLoad(assignedOperators: assignedOperators);
 
     private void SetupSuccessfulDataLoadWithMerchants(List<RecentMerchantsModel> merchants)

--- a/EstateManagementUI.BlazorServer.Tests/Pages/Operators/OperatorsIndexPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Operators/OperatorsIndexPageTests.cs
@@ -1,8 +1,9 @@
 using Bunit;
 using EstateManagementUI.BlazorServer.Components.Permissions;
+using EstateManagementUI.BlazorServer.Models;
 using EstateManagementUI.BlazorServer.Permissions;
 using EstateManagementUI.BlazorServer.Tests.Pages.FileProcessing;
-using EstateManagementUI.BusinessLogic.Models;
+using EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects;
 using EstateManagementUI.BusinessLogic.Requests;
 using MediatR;
 using Microsoft.AspNetCore.Components;
@@ -20,9 +21,9 @@ public class OperatorsIndexPageTests : BaseTest
     public void OperatorsIndex_RendersCorrectly()
     {
         // Arrange
-        var operators = new List<OperatorModel>
+        var operators = new List<OperatorModels.OperatorModel>
         {
-            new OperatorModel
+            new OperatorModels.OperatorModel
             {
                 OperatorId = Guid.NewGuid(),
                 Name = "Test Operator",
@@ -31,7 +32,7 @@ public class OperatorsIndexPageTests : BaseTest
             }
         };
         
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
+        this.OperatorUIService.Setup(o => o.GetOperators(It.IsAny<CorrelationId>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(operators));
         
         // Act
@@ -45,10 +46,10 @@ public class OperatorsIndexPageTests : BaseTest
     public void OperatorsIndex_WithNoOperators_ShowsEmptyState()
     {
         // Arrange
-        var emptyList = new List<OperatorModel>();
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
+        var emptyList = new List<OperatorModels.OperatorModel>();
+        this.OperatorUIService.Setup(o => o.GetOperators(It.IsAny<CorrelationId>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(emptyList));
-        
+
         // Act
         var cut = RenderComponent<OperatorsIndex>();
         cut.WaitForState(() => !cut.Markup.Contains("animate-spin"));
@@ -61,16 +62,16 @@ public class OperatorsIndexPageTests : BaseTest
     public void OperatorsIndex_WithOperators_DisplaysOperatorList()
     {
         // Arrange
-        var operators = new List<OperatorModel>
+        var operators = new List<OperatorModels.OperatorModel>
         {
-            new OperatorModel
+            new OperatorModels.OperatorModel
             {
                 OperatorId = Guid.NewGuid(),
                 Name = "Operator 1",
                 RequireCustomMerchantNumber = true,
                 RequireCustomTerminalNumber = false
             },
-            new OperatorModel
+            new OperatorModels.OperatorModel
             {
                 OperatorId = Guid.NewGuid(),
                 Name = "Operator 2",
@@ -78,10 +79,10 @@ public class OperatorsIndexPageTests : BaseTest
                 RequireCustomTerminalNumber = true
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
+
+        this.OperatorUIService.Setup(o => o.GetOperators(It.IsAny<CorrelationId>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(operators));
-        
+
         // Act
         var cut = RenderComponent<OperatorsIndex>();
         cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
@@ -95,9 +96,9 @@ public class OperatorsIndexPageTests : BaseTest
     public void OperatorsIndex_DisplaysCustomNumberRequirements()
     {
         // Arrange
-        var operators = new List<OperatorModel>
+        var operators = new List<OperatorModels.OperatorModel>
         {
-            new OperatorModel
+            new OperatorModels.OperatorModel
             {
                 OperatorId = Guid.NewGuid(),
                 Name = "Test Operator",
@@ -105,10 +106,10 @@ public class OperatorsIndexPageTests : BaseTest
                 RequireCustomTerminalNumber = false
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
+
+        this.OperatorUIService.Setup(o => o.GetOperators(It.IsAny<CorrelationId>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(operators));
-        
+
         // Act
         var cut = RenderComponent<OperatorsIndex>();
         cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
@@ -122,9 +123,9 @@ public class OperatorsIndexPageTests : BaseTest
     public void OperatorsIndex_HasCorrectPageTitle()
     {
         // Arrange
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorModel>()));
-        
+        this.OperatorUIService.Setup(o => o.GetOperators(It.IsAny<CorrelationId>(), It.IsAny<Guid>()))
+            .ReturnsAsync(Result.Success(new List<OperatorModels.OperatorModel>()));
+
         // Act
         var cut = RenderComponent<OperatorsIndex>();
         

--- a/EstateManagementUI.BlazorServer.Tests/Pages/Operators/OperatorsViewPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Operators/OperatorsViewPageTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Shouldly;
 using SimpleResults;
-using OperatorModel = EstateManagementUI.BusinessLogic.Models.OperatorModel;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages.Operators;
 
@@ -20,15 +19,15 @@ public class OperatorsViewPageTests : BaseTest
     {
         // Arrange
         var operatorId = Guid.NewGuid();
-        var operatorModel = new OperatorModel
+        var operatorModel = new OperatorModels.OperatorModel
         {
             OperatorId = operatorId,
             Name = "Test Operator"
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorQuery>(), default))
+
+        this.OperatorUIService.Setup(o => o.GetOperator(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(operatorModel));
-        
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.OperatorId, operatorId));
@@ -42,15 +41,15 @@ public class OperatorsViewPageTests : BaseTest
     {
         // Arrange
         var operatorId = Guid.NewGuid();
-        var operatorModel = new OperatorModel
+        var operatorModel = new OperatorModels.OperatorModel
         {
             OperatorId = operatorId,
             Name = "Test Operator"
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorQuery>(), default))
+
+        this.OperatorUIService.Setup(o => o.GetOperator(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(operatorModel));
-        
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.OperatorId, operatorId));
@@ -65,8 +64,8 @@ public class OperatorsViewPageTests : BaseTest
     {
         // Arrange
         var operatorId = Guid.NewGuid();
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorQuery>(), default))
-            .ReturnsAsync(Result.Success(new OperatorModel { OperatorId = operatorId }));
+        this.OperatorUIService.Setup(o => o.GetOperator(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
+            .ReturnsAsync(Result.Success(new OperatorModels.OperatorModel { OperatorId = operatorId }));
         
         // Act
         var cut = RenderComponent<View>(parameters => parameters

--- a/EstateManagementUI.BlazorServer.Tests/UIServices/OperatorUIServiceTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/UIServices/OperatorUIServiceTests.cs
@@ -1,0 +1,191 @@
+﻿    using EstateManagementUI.BlazorServer.UIServices;
+    using EstateManagementUI.BusinessLogic.Requests;
+    using MediatR;
+    using Moq;
+    using Shouldly;
+    using SimpleResults;
+    
+    namespace EstateManagementUI.BlazorServer.Tests.UIServices;
+
+    public class OperatorUIServiceTests
+    {
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly OperatorUIService _service;
+
+        public OperatorUIServiceTests()
+        {
+            _mockMediator = new Mock<IMediator>();
+            _service = new OperatorUIService(_mockMediator.Object);
+        }
+
+        [Fact]
+        public async Task GetOperators_ReturnsMappedList_WhenMediatorSucceeds()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var correlationId = CorrelationIdHelper.New();
+
+            var bizOperators = new List<EstateManagementUI.BusinessLogic.Models.OperatorModel>
+            {
+                new() { OperatorId = Guid.NewGuid(), Name = "OpA", RequireCustomMerchantNumber = true, RequireCustomTerminalNumber = false }
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success(bizOperators));
+
+            // Act
+            var result = await _service.GetOperators(correlationId, estateId);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            result.Data.ShouldNotBeNull();
+            result.Data!.Count.ShouldBe(1);
+            var mapped = result.Data.First();
+            mapped.OperatorId.ShouldBe(bizOperators[0].OperatorId);
+            mapped.Name.ShouldBe("OpA");
+            mapped.RequireCustomMerchantNumber.ShouldBeTrue();
+            mapped.RequireCustomTerminalNumber.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task GetOperators_ReturnsFailure_WhenMediatorFails()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<OperatorQueries.GetOperatorsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure("failure"));
+
+            // Act
+            var result = await _service.GetOperators(CorrelationIdHelper.New(), Guid.NewGuid());
+
+            // Assert
+            result.IsFailed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task GetOperator_ReturnsMappedModel_WhenMediatorSucceeds()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var correlationId = CorrelationIdHelper.New();
+            var operatorId = Guid.NewGuid();
+
+            var bizOperator = new EstateManagementUI.BusinessLogic.Models.OperatorModel
+            {
+                OperatorId = operatorId,
+                Name = "OpDetail",
+                RequireCustomMerchantNumber = false,
+                RequireCustomTerminalNumber = true
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<OperatorQueries.GetOperatorQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success(bizOperator));
+
+            // Act
+            var result = await _service.GetOperator(correlationId, estateId, operatorId);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            var model = result.Data!;
+            model.OperatorId.ShouldBe(operatorId);
+            model.Name.ShouldBe("OpDetail");
+            model.RequireCustomMerchantNumber.ShouldBeFalse();
+            model.RequireCustomTerminalNumber.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task GetOperator_ReturnsFailure_WhenMediatorFails()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<OperatorQueries.GetOperatorQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure("not found"));
+
+            // Act
+            var result = await _service.GetOperator(CorrelationIdHelper.New(), Guid.NewGuid(), Guid.NewGuid());
+
+            // Assert
+            result.IsFailed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UpdateOperator_CallsMediatorWithCorrectCommand_AndReturnsResult()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var correlationId = CorrelationIdHelper.New();
+            var operatorId = Guid.NewGuid();
+
+            var editModel = new EstateManagementUI.BlazorServer.Models.OperatorModels.EditOperatorModel
+            {
+                OperatorName = "UpdatedName",
+                RequireCustomMerchantNumber = true,
+                RequireCustomTerminalNumber = false
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<OperatorCommands.UpdateOperatorCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success);
+
+            // Act
+            var result = await _service.UpdateOperator(correlationId, estateId, operatorId, editModel);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            _mockMediator.Verify(m => m.Send(It.Is<OperatorCommands.UpdateOperatorCommand>(c =>
+                c.EstateId == estateId &&
+                c.OperatorId == operatorId &&
+                c.Name == editModel.OperatorName &&
+                c.RequireCustomMerchantNumber == editModel.RequireCustomMerchantNumber &&
+                c.RequireCustomTerminalNumber == editModel.RequireCustomTerminalNumber
+            ), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateOperator_CallsMediatorWithCorrectCommand_AndReturnsResult()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var correlationId = CorrelationIdHelper.New();
+
+            var createModel = new EstateManagementUI.BlazorServer.Models.OperatorModels.CreateOperatorModel
+            {
+                OperatorName = "NewOperator",
+                RequireCustomMerchantNumber = false,
+                RequireCustomTerminalNumber = true
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<OperatorCommands.CreateOperatorCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success);
+
+            // Act
+            var result = await _service.CreateOperator(correlationId, estateId, createModel);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            _mockMediator.Verify(m => m.Send(It.Is<OperatorCommands.CreateOperatorCommand>(c =>
+                c.EstateId == estateId &&
+                c.Name == createModel.OperatorName &&
+                c.RequireCustomMerchantNumber == createModel.RequireCustomMerchantNumber &&
+                c.RequireCustomTerminalNumber == createModel.RequireCustomTerminalNumber
+            ), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateOperator_ReturnsFailure_WhenMediatorFails()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<OperatorCommands.CreateOperatorCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure);
+
+            // Act
+            var result = await _service.CreateOperator(CorrelationIdHelper.New(), Guid.NewGuid(), new EstateManagementUI.BlazorServer.Models.OperatorModels.CreateOperatorModel { OperatorName = "x" });
+
+            // Assert
+            result.IsFailed.ShouldBeTrue();
+        }
+    }

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/New.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/New.razor.cs
@@ -13,7 +13,7 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Contracts
         private bool isLoadingOperators = true;
         private bool hasPermission = false;
         private string? errorMessage;
-        private List<OperatorDropDownModel>? operators;
+        private List<OperatorModels.OperatorDropDownModel>? operators;
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {

--- a/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor
@@ -4,7 +4,7 @@
 @inherits AuthorizedComponentBase
 @rendermode InteractiveServer
 @inject NavigationManager NavigationManager
-@inject IEstateUIService EstateUIService
+@inject IEstateUIService EstateUiService
 
 <PageTitle>Estate Management</PageTitle>
 

--- a/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Estate/Index.razor.cs
@@ -23,17 +23,13 @@ public partial class Index {
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender) {
-        if (!firstRender) {
+        if (!firstRender)
+        {
             return;
         }
-
-        Result authResult = await RequirePermission(PermissionSection.Estate, PermissionFunction.View);
-        if (authResult.IsFailed)
-            return;
-
-        Result result = await this.LoadEstateData();
-        if (result.IsFailed) {
-            this.NavigationManager.NavigateToErrorPage();
+        Result result = await OnAfterRender(PermissionSection.Operator, PermissionFunction.Edit, this.LoadEstateData);
+        if (result.IsFailed)
+        {
             return;
         }
 
@@ -44,7 +40,7 @@ public partial class Index {
     private async Task<Result> LoadEstateData() {
         CorrelationId correlationId = new(Guid.NewGuid());
         Guid estateId = await this.GetEstateId();
-        Result<EstateModel> result = await this.EstateUIService.LoadEstate(correlationId, estateId);
+        Result<EstateModel> result = await this.EstateUiService.LoadEstate(correlationId, estateId);
         if (result.IsFailed) {
             return ResultHelpers.CreateFailure(result);
         }
@@ -62,7 +58,7 @@ public partial class Index {
             CorrelationId correlationId = new CorrelationId(Guid.NewGuid());
             Guid estateId = await this.GetEstateId();
             
-            var result = await this.EstateUIService.AddOperatorToEstate(correlationId, estateId, this.selectedOperatorId);
+            var result = await this.EstateUiService.AddOperatorToEstate(correlationId, estateId, this.selectedOperatorId);
 
             if (result.IsSuccess) {
                 successMessage = "Operator added successfully";
@@ -88,7 +84,7 @@ public partial class Index {
         try {
             CorrelationId correlationId = new CorrelationId(Guid.NewGuid());
             Guid estateId = await this.GetEstateId();
-            var result = await this.EstateUIService.RemoveOperatorFromEstate(correlationId, estateId, operatorId);
+            var result = await this.EstateUiService.RemoveOperatorFromEstate(correlationId, estateId, operatorId);
 
             if (result.IsSuccess) {
                 successMessage = "Operator removed successfully";

--- a/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor.cs
@@ -29,11 +29,11 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Merchants
         private MerchantEditModel merchantEditModel = new();
 
         // Operators
-        private List<OperatorDropDownModel>? availableOperators;
+        private List<OperatorModels.OperatorDropDownModel>? availableOperators;
         private List<MerchantOperatorModel> assignedOperators = new();
         private bool showAddOperator = false;
         private string? selectedOperatorId;
-        private OperatorModel? selectedOperator;
+        private OperatorModels.OperatorModel? selectedOperator;
         private string? merchantNumber;
         private string? terminalNumber;
         private string? merchantNumberError;

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/Edit.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/Edit.razor
@@ -3,8 +3,9 @@
 @using System.ComponentModel.DataAnnotations
 @using EstateManagementUI.BlazorServer.Factories
 @using EstateManagementUI.BlazorServer.Permissions
+@using EstateManagementUI.BlazorServer.UIServices
 @using EstateManagementUI.BusinessLogic.Requests
-@inject IMediator Mediator
+@inject IOperatorUIService OperatorUiService
 @inherits AuthorizedComponentBase
 @inject NavigationManager NavigationManager
 @inject IPermissionService PermissionService

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/Edit.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/Edit.razor.cs
@@ -1,10 +1,12 @@
 ﻿using EstateManagementUI.BlazorServer.Factories;
+using EstateManagementUI.BlazorServer.Models;
 using EstateManagementUI.BlazorServer.Permissions;
 using EstateManagementUI.BusinessLogic.Requests;
 using MediatR;
 using Microsoft.AspNetCore.Components;
+using Shared.Results;
+using SimpleResults;
 using System.ComponentModel.DataAnnotations;
-using EstateManagementUI.BlazorServer.Models;
 
 namespace EstateManagementUI.BlazorServer.Components.Pages.Operators
 {
@@ -13,121 +15,83 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Operators
         [Parameter]
         public Guid OperatorId { get; set; }
 
-        private OperatorModel? operatorModel;
-        private EditOperatorModel model = new();
+        private OperatorModels.OperatorModel? operatorModel;
+        private OperatorModels.EditOperatorModel model = new();
         private bool isLoading = true;
         private bool isSaving = false;
-        private bool hasPermission = false;
-        private string? errorMessage;
-        private string? successMessage;
-
+        
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (!firstRender)
             {
-                await base.OnAfterRenderAsync(firstRender);
+                return;
+            }
+            Result result = await OnAfterRender(PermissionSection.Operator, PermissionFunction.Edit, this.LoadOperator);
+            if (result.IsFailed)
+            {
                 return;
             }
 
-            await RequirePermission(PermissionSection.Operator, PermissionFunction.Edit);
-            await LoadOperator();
+            isLoading = false;
+            this.StateHasChanged();
         }
 
-        private async Task LoadOperator()
+        private async Task<Result> LoadOperator()
         {
-            try
+            var correlationId = new CorrelationId(Guid.NewGuid());
+            var estateId = await this.GetEstateId();
+
+            var result = await this.OperatorUiService.GetOperator(correlationId, estateId, this.OperatorId);
+
+            if (result.IsFailed)
             {
-                isLoading = true;
-                var correlationId = new CorrelationId(Guid.NewGuid());
-                var estateId = await GetEstateId();
-
-                var result = await Mediator.Send(new OperatorQueries.GetOperatorQuery(correlationId, estateId, OperatorId));
-
-                if (result.IsSuccess && result.Data != null)
-                {
-                    operatorModel = ModelFactory.ConvertFrom(result.Data);
-
-                    // Initialize model with current values
-                    model = new EditOperatorModel
-                    {
-                        OperatorName = operatorModel.Name,
-                        RequireCustomMerchantNumber = operatorModel.RequireCustomMerchantNumber,
-                        RequireCustomTerminalNumber = operatorModel.RequireCustomTerminalNumber
-                    };
-                }
+                return ResultHelpers.CreateFailure(result);
             }
-            finally
+
+            operatorModel = result.Data;
+
+            // Initialize model with current values
+            model = new OperatorModels.EditOperatorModel
             {
-                isLoading = false;
-                this.StateHasChanged();
-            }
+                OperatorName = operatorModel.Name,
+                RequireCustomMerchantNumber = operatorModel.RequireCustomMerchantNumber,
+                RequireCustomTerminalNumber = operatorModel.RequireCustomTerminalNumber
+            };
+
+            return Result.Success();
         }
+
 
         private async Task HandleSubmit()
         {
             isSaving = true;
             ClearMessages();
 
-            try
+            var correlationId = new CorrelationId(Guid.NewGuid());
+            var estateId = await this.GetEstateId();
+
+            var result = await this.OperatorUiService.UpdateOperator(correlationId, estateId, this.OperatorId, this.model);
+            if (result.IsSuccess)
             {
-                var correlationId = new CorrelationId(Guid.NewGuid());
-                var estateId = await this.GetEstateId();
+                successMessage = "Operator updated successfully";
+                StateHasChanged();
 
-                var command = new OperatorCommands.UpdateOperatorCommand(
-                    correlationId,
-                    estateId,
-                    OperatorId,
-                    model.OperatorName!,
-                    model.RequireCustomMerchantNumber,
-                    model.RequireCustomTerminalNumber
-                );
+                // Small delay so user sees confirmation (adjust duration as needed)
+                await this.WaitOnUIRefresh();
 
-                var result = await Mediator.Send(command);
-
-                if (result.IsSuccess)
-                {
-                    successMessage = "Operator updated successfully";
-                    StateHasChanged();
-
-                    // Small delay so user sees confirmation (adjust duration as needed)
-                    await this.WaitOnUIRefresh();
-
-                    NavigationManager.NavigateTo("/operators");
-                }
-                else
-                {
-                    errorMessage = result.Message ?? "Failed to update operator";
-                }
+                NavigationManager.NavigateTo("/operators");
             }
-            catch (Exception ex)
+            else
             {
-                errorMessage = $"An error occurred: {ex.Message}";
+                errorMessage = "Failed to update operator";
             }
-            finally
-            {
-                isSaving = false;
-            }
+        
+            isSaving = false;
         }
-
-        private void ClearMessages()
-        {
-            errorMessage = null;
-            successMessage = null;
-        }
-
+        
         private void BackToList()
         {
             NavigationManager.NavigateTo("/operators");
-        }
-
-        public class EditOperatorModel
-        {
-            [Required(ErrorMessage = "Operator name is required")]
-            public string? OperatorName { get; set; }
-
-            public bool RequireCustomMerchantNumber { get; set; }
-
-            public bool RequireCustomTerminalNumber { get; set; }
         }
     }
 }

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/Index.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/Index.razor
@@ -2,8 +2,9 @@
 @using EstateManagementUI.BlazorServer.Factories
 @rendermode InteractiveServer
 @using EstateManagementUI.BlazorServer.Permissions
+@using EstateManagementUI.BlazorServer.UIServices
 @using EstateManagementUI.BusinessLogic.Requests
-@inject IMediator Mediator
+@inject IOperatorUIService OperatorUiService
 @inherits AuthorizedComponentBase
 @inject NavigationManager NavigationManager
 @inject IPermissionKeyProvider PermissionKeyProvider

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/Index.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/Index.razor.cs
@@ -1,40 +1,47 @@
-﻿using EstateManagementUI.BlazorServer.Factories;
+﻿using EstateManagementUI.BlazorServer.Common;
 using EstateManagementUI.BlazorServer.Models;
 using EstateManagementUI.BlazorServer.Permissions;
+using EstateManagementUI.BusinessLogic.Models;
 using EstateManagementUI.BusinessLogic.Requests;
+using Shared.Results;
+using SimpleResults;
 
 namespace EstateManagementUI.BlazorServer.Components.Pages.Operators
 {
     public partial class Index
     {
         private bool isLoading = true;
-        private List<OperatorModel> operators;
+        private List<OperatorModels.OperatorModel> operators;
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (!firstRender)
             {
-                await base.OnAfterRenderAsync(firstRender);
                 return;
             }
-
-            try {
-                await RequirePermission(PermissionSection.Operator, PermissionFunction.List);
-
-                var correlationId = new CorrelationId(Guid.NewGuid());
-                var estateId = await this.GetEstateId();
-
-                var result = await Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
-                if (result.IsSuccess)
-                {
-                    operators = ModelFactory.ConvertFrom(result.Data);
-                }
+            Result result = await OnAfterRender(PermissionSection.Operator, PermissionFunction.List, this.LoadOperators);
+            if (result.IsFailed) {
+                return;
             }
-            finally
-            {
-                isLoading = false;
-                this.StateHasChanged();
+            
+            isLoading = false;
+            this.StateHasChanged();
+        }
+
+        private async Task<Result> LoadOperators()
+        {
+            var correlationId = new CorrelationId(Guid.NewGuid());
+            var estateId = await this.GetEstateId();
+
+            Result<List<OperatorModels.OperatorModel>> result = await this.OperatorUiService.GetOperators(correlationId, estateId);
+
+            if (result.IsFailed) {
+                return ResultHelpers.CreateFailure(result);
             }
+
+            operators = result.Data;
+
+            return Result.Success();
         }
     }
 }

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/New.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/New.razor
@@ -2,8 +2,9 @@
 @rendermode InteractiveServer
 @using System.ComponentModel.DataAnnotations
 @using EstateManagementUI.BlazorServer.Permissions
+@using EstateManagementUI.BlazorServer.UIServices
 @using EstateManagementUI.BusinessLogic.Requests
-@inject IMediator Mediator
+@inject IOperatorUIService OperatorUiService
 @inherits AuthorizedComponentBase
 @inject NavigationManager NavigationManager
 @inject IPermissionService PermissionService

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/View.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/View.razor
@@ -1,8 +1,9 @@
 @page "/operators/{OperatorId:guid}"
 @using EstateManagementUI.BlazorServer.Factories
+@using EstateManagementUI.BlazorServer.UIServices
 @using EstateManagementUI.BusinessLogic.Requests
 @rendermode InteractiveServer
-@inject IMediator Mediator
+@inject IOperatorUIService OperatorUiService
 @inherits AuthorizedComponentBase
 @inject NavigationManager NavigationManager
 

--- a/EstateManagementUI.BlazorServer/Components/Pages/Operators/View.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Operators/View.razor.cs
@@ -1,8 +1,11 @@
-﻿using EstateManagementUI.BlazorServer.Factories;
+﻿using EstateManagementUI.BlazorServer.Common;
+using EstateManagementUI.BlazorServer.Factories;
 using EstateManagementUI.BlazorServer.Models;
 using EstateManagementUI.BlazorServer.Permissions;
 using EstateManagementUI.BusinessLogic.Requests;
 using Microsoft.AspNetCore.Components;
+using Shared.Results;
+using SimpleResults;
 
 namespace EstateManagementUI.BlazorServer.Components.Pages.Operators
 {
@@ -11,42 +14,35 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Operators
         [Parameter]
         public Guid OperatorId { get; set; }
 
-        private OperatorModel? operatorModel;
+        private OperatorModels.OperatorModel? operatorModel;
         private bool isLoading = true;
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (!firstRender)
-            {
-                await base.OnAfterRenderAsync(firstRender);
+            if (!firstRender) {
                 return;
             }
-
-            await RequirePermission(PermissionSection.Operator, PermissionFunction.View);
-
-            await LoadOperator();
+            Result result = await OnAfterRender(PermissionSection.Operator, PermissionFunction.View, this.LoadOperator);
+            if (result.IsFailed) {
+                return;
+            }
+            isLoading = false;
+            this.StateHasChanged();
         }
+        
+        private async Task<Result> LoadOperator() {
+            var correlationId = new CorrelationId(Guid.NewGuid());
+            var estateId = await this.GetEstateId();
 
-        private async Task LoadOperator()
-        {
-            try
-            {
-                isLoading = true;
-                var correlationId = new CorrelationId(Guid.NewGuid());
-                var estateId = await this.GetEstateId();
+            var result = await this.OperatorUiService.GetOperator(correlationId, estateId, this.OperatorId);
 
-                var result = await Mediator.Send(new OperatorQueries.GetOperatorQuery(correlationId, estateId, OperatorId));
-
-                if (result.IsSuccess && result.Data != null)
-                {
-                    operatorModel = ModelFactory.ConvertFrom(result.Data);
-                }
+            if (result.IsFailed) {
+                return ResultHelpers.CreateFailure(result);
             }
-            finally
-            {
-                isLoading = false;
-                this.StateHasChanged();
-            }
+
+            operatorModel = result.Data;
+
+            return Result.Success();
         }
 
         private void BackToList()

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
@@ -8,8 +8,8 @@
 @using ContractProductModel = EstateManagementUI.BlazorServer.Models.ContractProductModel
 @using MerchantDropDownModel = EstateManagementUI.BlazorServer.Models.MerchantDropDownModel
 @using MerchantModel = EstateManagementUI.BlazorServer.Models.MerchantModel
-@using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorDropDownModel
-@using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModel
+@using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorDropDownModel
+@using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorModel
 @using TransactionDetailModel = EstateManagementUI.BlazorServer.Models.TransactionDetailModel
 @inject IMediator Mediator
 @inject NavigationManager Navigation

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryMerchant.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryMerchant.razor
@@ -4,8 +4,8 @@
 @using EstateManagementUI.BusinessLogic.Requests
 @using MerchantDropDownModel = EstateManagementUI.BlazorServer.Models.MerchantDropDownModel
 @using MerchantTransactionSummaryModel = EstateManagementUI.BlazorServer.Models.MerchantTransactionSummaryModel
-@using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorDropDownModel
-@using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModel
+@using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorDropDownModel
+@using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorModel
 @rendermode InteractiveServer
 @inject IMediator Mediator
 @inject NavigationManager Navigation

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryOperator.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryOperator.razor
@@ -3,8 +3,8 @@
 @using EstateManagementUI.BusinessLogic.Models
 @using EstateManagementUI.BusinessLogic.Requests
 @using MerchantDropDownModel = EstateManagementUI.BlazorServer.Models.MerchantDropDownModel
-@using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorDropDownModel
-@using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModel
+@using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorDropDownModel
+@using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorModel
 @using OperatorTransactionSummaryModel = EstateManagementUI.BlazorServer.Models.OperatorTransactionSummaryModel
 @rendermode InteractiveServer
 @inject IMediator Mediator

--- a/EstateManagementUI.BlazorServer/Components/Permissions/AuthorizedComponentBase.cs
+++ b/EstateManagementUI.BlazorServer/Components/Permissions/AuthorizedComponentBase.cs
@@ -72,4 +72,28 @@ public abstract class AuthorizedComponentBase : CustomComponentBase
         }
         return estateIdResult.Data;
     }
+
+    protected async Task<Result> OnAfterRender(PermissionSection section,
+                                               PermissionFunction function) =>
+        await OnAfterRender(section, function, null);
+
+    protected async Task<Result> OnAfterRender(PermissionSection section,
+                                               PermissionFunction function,
+                                               Func<Task<Result>>? loadFunc)
+    {
+        Result authResult = await RequirePermission(section, function);
+        if (authResult.IsFailed)
+            return Result.Failure();
+
+        if (loadFunc == null)
+            return Result.Success();
+
+        Result result = await loadFunc();
+        if (result.IsFailed)
+        {
+            this.NavigationManager.NavigateToErrorPage();
+            return Result.Failure();
+        }
+        return Result.Success();
+    }
 }

--- a/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
+++ b/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
@@ -2,7 +2,7 @@
 using TransactionProcessor.DataTransferObjects.Responses.Contract;
 using ComparisonDateModel = EstateManagementUI.BlazorServer.Models.ComparisonDateModel;
 using ContractDropDownModel = EstateManagementUI.BlazorServer.Models.ContractDropDownModel;
-using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorDropDownModel;
+using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorDropDownModel;
 using ContractModel = EstateManagementUI.BlazorServer.Models.ContractModel;
 using ContractProductModel = EstateManagementUI.BlazorServer.Models.ContractProductModel;
 using ContractProductTransactionFeeModel = EstateManagementUI.BlazorServer.Models.ContractProductTransactionFeeModel;
@@ -18,7 +18,7 @@ using MerchantModel = EstateManagementUI.BlazorServer.Models.MerchantModel;
 using MerchantOperatorModel = EstateManagementUI.BlazorServer.Models.MerchantOperatorModel;
 using MerchantSettlementHistoryModel = EstateManagementUI.BlazorServer.Models.MerchantSettlementHistoryModel;
 using MerchantTransactionSummaryModel = EstateManagementUI.BlazorServer.Models.MerchantTransactionSummaryModel;
-using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModel;
+using OperatorModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorModel;
 using OperatorTransactionSummaryModel = EstateManagementUI.BlazorServer.Models.OperatorTransactionSummaryModel;
 using ProductPerformanceModel = EstateManagementUI.BlazorServer.Models.ProductPerformanceModel;
 using RecentContractModel = EstateManagementUI.BlazorServer.Models.RecentContractModel;

--- a/EstateManagementUI.BlazorServer/Models/Models.cs
+++ b/EstateManagementUI.BlazorServer/Models/Models.cs
@@ -9,8 +9,8 @@ public record EstateModel(Guid EstateId, string? EstateName, string? Reference) 
     public Int32 UserCount { get; init; }
     public List<RecentMerchantsModel> RecentMerchants { get; init; }
     public List<RecentContractModel> RecentContracts { get; init; }
-    public List<OperatorModel> AssignedOperators { get; init; }
-    public List<OperatorDropDownModel> AllOperators { get; init; }
+    public List<OperatorModels.OperatorModel> AssignedOperators { get; init; }
+    public List<OperatorModels.OperatorDropDownModel> AllOperators { get; init; }
 }
 
 
@@ -36,24 +36,11 @@ public class MerchantModel
 }
 
 // Operator Models
-public class OperatorModel
-{
-    public Guid OperatorId { get; set; }
-    public string? Name { get; set; }
-    public bool RequireCustomMerchantNumber { get; set; }
-    public bool RequireCustomTerminalNumber { get; set; }
-}
 
 public class ContractDropDownModel
 {
     public Guid ContractId { get; set; }
     public string? Description { get; set; }
-    public string? OperatorName { get; set; }
-}
-
-public class OperatorDropDownModel
-{
-    public Guid OperatorId { get; set; }
     public string? OperatorName { get; set; }
 }
 

--- a/EstateManagementUI.BlazorServer/Models/OperatorModels.cs
+++ b/EstateManagementUI.BlazorServer/Models/OperatorModels.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EstateManagementUI.BlazorServer.Models;
+
+public record OperatorModels {
+    public record EditOperatorModel {
+        [Required(ErrorMessage = "Operator name is required")]
+        public string? OperatorName { get; set; }
+
+        public bool RequireCustomMerchantNumber { get; set; }
+
+        public bool RequireCustomTerminalNumber { get; set; }
+    }
+
+    public record OperatorModel
+    {
+        public Guid OperatorId { get; set; }
+        public string? Name { get; set; }
+        public bool RequireCustomMerchantNumber { get; set; }
+        public bool RequireCustomTerminalNumber { get; set; }
+    }
+
+    public class OperatorDropDownModel
+    {
+        public Guid OperatorId { get; set; }
+        public string? OperatorName { get; set; }
+    }
+
+    public class CreateOperatorModel
+    {
+        [Required(ErrorMessage = "Operator name is required")]
+        public string? OperatorName { get; set; }
+
+        public bool RequireCustomMerchantNumber { get; set; }
+
+        public bool RequireCustomTerminalNumber { get; set; }
+    }
+}

--- a/EstateManagementUI.BlazorServer/Program.cs
+++ b/EstateManagementUI.BlazorServer/Program.cs
@@ -242,6 +242,7 @@ else
     builder.Services.RegisterHttpClient<ITransactionProcessorClient, TransactionProcessorClient>();
     
     builder.Services.AddSingleton<IEstateUIService, EstateUIService>();
+    builder.Services.AddSingleton<IOperatorUIService, OperatorUIService>();
 }
 
 builder.Host.UseWindowsService();

--- a/EstateManagementUI.BlazorServer/UIServices/EstateUIService.cs
+++ b/EstateManagementUI.BlazorServer/UIServices/EstateUIService.cs
@@ -5,97 +5,96 @@ using MediatR;
 using Shared.Results;
 using SimpleResults;
 
-namespace EstateManagementUI.BlazorServer.UIServices
-{
-    public interface IEstateUIService
-    {
-        Task<Result<EstateModel>> LoadEstate(CorrelationId correlationId, Guid estateId);
+namespace EstateManagementUI.BlazorServer.UIServices;
 
-        Task<Result> AddOperatorToEstate(CorrelationId correlationId, Guid estateId, String selectedOperatorId);
-        Task<Result> RemoveOperatorFromEstate(CorrelationId correlationId, Guid estateId, Guid selectedOperatorId);
+public interface IEstateUIService
+{
+    Task<Result<EstateModel>> LoadEstate(CorrelationId correlationId, Guid estateId);
+
+    Task<Result> AddOperatorToEstate(CorrelationId correlationId, Guid estateId, String selectedOperatorId);
+    Task<Result> RemoveOperatorFromEstate(CorrelationId correlationId, Guid estateId, Guid selectedOperatorId);
+}
+
+public class EstateUIService : IEstateUIService
+{
+    private readonly IMediator Mediator;
+
+    public EstateUIService(IMediator mediator)
+    {
+        this.Mediator = mediator;
     }
 
-    public class EstateUIService : IEstateUIService
+    public async Task<Result<EstateModel>> LoadEstate(CorrelationId correlationId,
+                                                      Guid estateId)
     {
-        private readonly IMediator Mediator;
+        Task<Result<BusinessLogic.Models.EstateModel>> estateTask = Mediator.Send(new EstateQueries.GetEstateQuery(correlationId, estateId));
+        Task<Result<List<BusinessLogic.Models.RecentMerchantsModel>>> merchantTask = Mediator.Send(new MerchantQueries.GetRecentMerchantsQuery(correlationId, estateId));
+        Task<Result<List<BusinessLogic.Models.RecentContractModel>>> contractsTask = Mediator.Send(new ContractQueries.GetRecentContractsQuery(correlationId, estateId));
+        Task<Result<List<BusinessLogic.Models.OperatorModel>>> assignedOperatorsTask = Mediator.Send(new EstateQueries.GetAssignedOperatorsQuery(correlationId, estateId));
+        Task<Result<List<BusinessLogic.Models.OperatorDropDownModel>>> allOperatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsForDropDownQuery(correlationId, estateId));
 
-        public EstateUIService(IMediator mediator)
+        await Task.WhenAll(estateTask, merchantTask, contractsTask, assignedOperatorsTask, allOperatorsTask);
+
+        if (estateTask.Result.IsFailed)
+            return ResultHelpers.CreateFailure(estateTask.Result);
+
+        if (merchantTask.Result.IsFailed)
+            return ResultHelpers.CreateFailure(merchantTask.Result);
+        var merchants = ModelFactory.ConvertFrom(merchantTask.Result.Data);
+
+        if (contractsTask.Result.IsFailed)
+            return ResultHelpers.CreateFailure(contractsTask.Result);
+        var contracts = ModelFactory.ConvertFrom(contractsTask.Result.Data);
+
+        if (assignedOperatorsTask.Result.IsFailed)
+            return ResultHelpers.CreateFailure(assignedOperatorsTask.Result);
+        var assignedOperators = ModelFactory.ConvertFrom(assignedOperatorsTask.Result.Data);
+
+        if (allOperatorsTask.Result.IsFailed)
+            return ResultHelpers.CreateFailure(allOperatorsTask.Result);
+
+        List<OperatorModels.OperatorDropDownModel> unfiltered = ModelFactory.ConvertFrom(allOperatorsTask.Result.Data);
+        var availableOperators = unfiltered.Where(u => !assignedOperators.Any(a => a.OperatorId == u.OperatorId)).Select(u => new OperatorModels.OperatorDropDownModel { OperatorId = u.OperatorId, OperatorName = u.OperatorName }).ToList();
+        var estateModel = estateTask.Result.Data;
+        var resultModel = new EstateModel(estateModel.EstateId, estateModel.EstateName, estateModel.Reference);
+        resultModel = resultModel with
         {
-            this.Mediator = mediator;
-        }
+            MerchantCount = estateModel.Merchants.Count,
+            AllOperators = availableOperators,
+            AssignedOperators = assignedOperators,
+            ContractCount = estateModel.Contracts.Count,
+            RecentContracts = contracts,
+            RecentMerchants = merchants,
+            UserCount = estateModel.Users.Count,
+        };
 
-        public async Task<Result<EstateModel>> LoadEstate(CorrelationId correlationId,
-                                                          Guid estateId)
-        {
-            Task<Result<BusinessLogic.Models.EstateModel>> estateTask = Mediator.Send(new EstateQueries.GetEstateQuery(correlationId, estateId));
-            Task<Result<List<BusinessLogic.Models.RecentMerchantsModel>>> merchantTask = Mediator.Send(new MerchantQueries.GetRecentMerchantsQuery(correlationId, estateId));
-            Task<Result<List<BusinessLogic.Models.RecentContractModel>>> contractsTask = Mediator.Send(new ContractQueries.GetRecentContractsQuery(correlationId, estateId));
-            Task<Result<List<BusinessLogic.Models.OperatorModel>>> assignedOperatorsTask = Mediator.Send(new EstateQueries.GetAssignedOperatorsQuery(correlationId, estateId));
-            Task<Result<List<BusinessLogic.Models.OperatorDropDownModel>>> allOperatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsForDropDownQuery(correlationId, estateId));
+        return Result.Success(resultModel);
+    }
 
-            await Task.WhenAll(estateTask, merchantTask, contractsTask, assignedOperatorsTask, allOperatorsTask);
+    public async Task<Result> AddOperatorToEstate(CorrelationId correlationId,
+                                                  Guid estateId, String selectedOperatorId)
+    {
+        var operatorId = Guid.Parse(selectedOperatorId);
 
-            if (estateTask.Result.IsFailed)
-                return ResultHelpers.CreateFailure(estateTask.Result);
+        var command = new EstateCommands.AddOperatorToEstateCommand(correlationId, estateId, operatorId);
 
-            if (merchantTask.Result.IsFailed)
-                return ResultHelpers.CreateFailure(merchantTask.Result);
-            var merchants = ModelFactory.ConvertFrom(merchantTask.Result.Data);
+        var result = await Mediator.Send(command);
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
 
-            if (contractsTask.Result.IsFailed)
-                return ResultHelpers.CreateFailure(contractsTask.Result);
-            var contracts = ModelFactory.ConvertFrom(contractsTask.Result.Data);
+        return Result.Success();
+    }
 
-            if (assignedOperatorsTask.Result.IsFailed)
-                return ResultHelpers.CreateFailure(assignedOperatorsTask.Result);
-            var assignedOperators = ModelFactory.ConvertFrom(assignedOperatorsTask.Result.Data);
+    public async Task<Result> RemoveOperatorFromEstate(CorrelationId correlationId,
+                                                       Guid estateId,
+                                                       Guid operatorId)
+    {
+        var command = new EstateCommands.RemoveOperatorFromEstateCommand(correlationId, estateId, operatorId);
 
-            if (allOperatorsTask.Result.IsFailed)
-                return ResultHelpers.CreateFailure(allOperatorsTask.Result);
+        var result = await Mediator.Send(command);
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
 
-            List<OperatorDropDownModel> unfiltered = ModelFactory.ConvertFrom(allOperatorsTask.Result.Data);
-            var availableOperators = unfiltered.Where(u => !assignedOperators.Any(a => a.OperatorId == u.OperatorId)).Select(u => new OperatorDropDownModel { OperatorId = u.OperatorId, OperatorName = u.OperatorName }).ToList();
-            var estateModel = estateTask.Result.Data;
-            var resultModel = new EstateModel(estateModel.EstateId, estateModel.EstateName, estateModel.Reference);
-            resultModel = resultModel with
-            {
-                MerchantCount = estateModel.Merchants.Count,
-                AllOperators = availableOperators,
-                AssignedOperators = assignedOperators,
-                ContractCount = estateModel.Contracts.Count,
-                RecentContracts = contracts,
-                RecentMerchants = merchants,
-                UserCount = estateModel.Users.Count,
-            };
-
-            return Result.Success(resultModel);
-        }
-
-        public async Task<Result> AddOperatorToEstate(CorrelationId correlationId,
-                                              Guid estateId, String selectedOperatorId)
-        {
-            var operatorId = Guid.Parse(selectedOperatorId);
-
-            var command = new EstateCommands.AddOperatorToEstateCommand(correlationId, estateId, operatorId);
-
-            var result = await Mediator.Send(command);
-            if (result.IsFailed)
-                return ResultHelpers.CreateFailure(result);
-
-            return Result.Success();
-        }
-
-        public async Task<Result> RemoveOperatorFromEstate(CorrelationId correlationId,
-                                                           Guid estateId,
-                                                           Guid operatorId)
-        {
-            var command = new EstateCommands.RemoveOperatorFromEstateCommand(correlationId, estateId, operatorId);
-
-            var result = await Mediator.Send(command);
-            if (result.IsFailed)
-                return ResultHelpers.CreateFailure(result);
-
-            return Result.Success();
-        }
+        return Result.Success();
     }
 }

--- a/EstateManagementUI.BlazorServer/UIServices/OperatorUIService.cs
+++ b/EstateManagementUI.BlazorServer/UIServices/OperatorUIService.cs
@@ -1,0 +1,69 @@
+﻿using EstateManagementUI.BlazorServer.Factories;
+using EstateManagementUI.BlazorServer.Models;
+using EstateManagementUI.BusinessLogic.Requests;
+using MediatR;
+using Shared.Results;
+using SimpleResults;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
+
+namespace EstateManagementUI.BlazorServer.UIServices;
+
+public interface IOperatorUIService
+{
+    Task<Result<List<OperatorModels.OperatorModel>>> GetOperators(CorrelationId correlationId, Guid estateId);
+    Task<Result<OperatorModels.OperatorModel>> GetOperator(CorrelationId correlationId, Guid estateId, Guid operatorId);
+
+    Task<Result> UpdateOperator(CorrelationId correlationId, Guid estateId, Guid operatorId, OperatorModels.EditOperatorModel editOperatorModel);
+    Task<Result> CreateOperator(CorrelationId correlationId, Guid estateId, OperatorModels.CreateOperatorModel createOperatorModel);
+}
+public class OperatorUIService : IOperatorUIService
+{
+    private readonly IMediator Mediator;
+    public OperatorUIService(IMediator mediator)
+    {
+        this.Mediator = mediator;
+    }
+    public async Task<Result<List<OperatorModels.OperatorModel>>> GetOperators(CorrelationId correlationId, Guid estateId)
+    {
+        var result = await this.Mediator.Send(new OperatorQueries.GetOperatorsQuery(correlationId, estateId));
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
+        var operators = ModelFactory.ConvertFrom(result.Data);
+        return Result.Success(operators);
+    }
+
+    public async Task<Result<OperatorModels.OperatorModel>> GetOperator(CorrelationId correlationId,
+                                                         Guid estateId,
+                                                         Guid operatorId) {
+        var result = await this.Mediator.Send(new OperatorQueries.GetOperatorQuery(correlationId, estateId, operatorId));
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
+        var @operator = ModelFactory.ConvertFrom(result.Data);
+        return Result.Success(@operator);
+    }
+
+    public async Task<Result> UpdateOperator(CorrelationId correlationId,
+                                             Guid estateId,
+                                             Guid operatorId,
+                                             OperatorModels.EditOperatorModel editOperatorModel) {
+        var command = new OperatorCommands.UpdateOperatorCommand(correlationId, estateId, operatorId, editOperatorModel.OperatorName, editOperatorModel.RequireCustomMerchantNumber, editOperatorModel.RequireCustomTerminalNumber);
+
+        var result = await Mediator.Send(command);
+        return result;
+    }
+
+    public async Task<Result> CreateOperator(CorrelationId correlationId,
+                                             Guid estateId,
+                                             OperatorModels.CreateOperatorModel createOperatorModel) {
+        // Create operator
+        var command = new OperatorCommands.CreateOperatorCommand(correlationId,
+            estateId,
+            createOperatorModel.OperatorName!,
+            createOperatorModel.RequireCustomMerchantNumber,
+            createOperatorModel.RequireCustomTerminalNumber
+        );
+
+        var result = await Mediator.Send(command);
+        return result;
+    }
+}


### PR DESCRIPTION
Major refactor to introduce OperatorUIService for all operator-related UI operations, replacing direct MediatR usage in Blazor components. Added OperatorModels.cs to encapsulate operator models and updated all references. Registered IOperatorUIService in DI. Refactored operator pages to use the new service, improved permission handling, and updated tests. Cleaned up legacy model definitions and improved naming consistency. No changes to business logic or API contracts.

closes #741 