### PR TITLE
Refactor contract UI to use ContractUIService abstraction

### DIFF
--- a/EstateManagementUI.BlazorServer.Tests/Pages/BaseTest.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/BaseTest.cs
@@ -34,6 +34,7 @@ public abstract class BaseTest :TestContext {
         this.Services.AddSingleton(this._mockPermissionStore.Object);
         this.Services.AddSingleton(this.EstateUIService.Object);
         this.Services.AddSingleton(this.OperatorUIService.Object);
+        this.Services.AddSingleton(this.ContractUIService.Object);
 
 
         // Add required permission components that render their children
@@ -55,6 +56,7 @@ public abstract class BaseTest :TestContext {
     protected readonly FakeNavigationManager _fakeNavigationManager;
     protected readonly Mock<IEstateUIService> EstateUIService = new Mock<IEstateUIService>();
     protected readonly Mock<IOperatorUIService> OperatorUIService = new Mock<IOperatorUIService>();
+    protected readonly Mock<IContractUIService> ContractUIService = new Mock<IContractUIService>();
     /// <summary>
     /// Minimal test double for NavigationManager.
     /// Register in DI as NavigationManager so components receive it in tests.

--- a/EstateManagementUI.BlazorServer.Tests/Pages/Contracts/ContractsEditPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Contracts/ContractsEditPageTests.cs
@@ -2,6 +2,7 @@ using AngleSharp.Dom;
 using Bunit;
 using EstateManagementUI.BlazorServer.Components.Pages.Contracts;
 using EstateManagementUI.BlazorServer.Components.Permissions;
+using EstateManagementUI.BlazorServer.Models;
 using EstateManagementUI.BlazorServer.Permissions;
 using EstateManagementUI.BusinessLogic.Models;
 using EstateManagementUI.BusinessLogic.Requests;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Shouldly;
 using SimpleResults;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages.Contracts;
 
@@ -21,15 +23,15 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
         
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
         
         // Act
@@ -45,17 +47,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -71,13 +73,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Success(new ContractModel 
-            { 
-                ContractId = contractId,
-                Products = new List<ContractProductModel>()
-            }));
-        
+        var contract = new ContractModels.ContractModel
+        {
+            ContractId = contractId,
+            Description = "Test Contract",
+            OperatorName = "Test Operator",
+            Products = new List<ContractModels.ContractProductModel>()
+        };
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
+            .ReturnsAsync(Result.Success(contract));
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -86,54 +92,23 @@ public class ContractsEditPageTests : BaseTest
         var pageTitle = cut.FindComponent<Microsoft.AspNetCore.Components.Web.PageTitle>();
         pageTitle.Instance.ChildContent.ShouldNotBeNull();
     }
-
-    [Fact]
-    public void ContractsEdit_CancelButton_NavigatesToViewPage()
-    {
-        // Arrange
-        var contractId = Guid.NewGuid();
-        var contract = new ContractModel
-        {
-            ContractId = contractId,
-            Description = "Test Contract",
-            OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
-        };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Success(contract));
-        
-        // Act
-        var cut = RenderComponent<Edit>(parameters => parameters
-            .Add(p => p.ContractId, contractId));
-        cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
-        
-        // Find and click Cancel button
-        IRefreshableElementCollection<IElement> buttons = cut.FindAll("button");
-        IElement? cancelButton = buttons.FirstOrDefault(b => b.TextContent.Contains("Cancel"));
-        cancelButton.ShouldNotBeNull();
-        cancelButton.Click();
-        
-        // Assert
-        _fakeNavigationManager.Uri.ShouldContain($"/contracts/{contractId}");
-    }
-
+    
     [Fact]
     public void ContractsEdit_UpdateContractButton_CanBeFound()
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -152,17 +127,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -181,17 +156,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -212,29 +187,29 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = Guid.NewGuid(),
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 2,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -251,29 +226,29 @@ public class ContractsEditPageTests : BaseTest
         // Arrange
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 0,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -294,24 +269,24 @@ public class ContractsEditPageTests : BaseTest
         // Arrange
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 1,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>
                     {
-                        new ContractProductTransactionFeeModel
+                        new ContractModels.ContractProductTransactionFeeModel
                         {
                             TransactionFeeId = Guid.NewGuid(),
                             Description = "Fee 1",
@@ -323,10 +298,10 @@ public class ContractsEditPageTests : BaseTest
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -347,29 +322,29 @@ public class ContractsEditPageTests : BaseTest
         // Arrange
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 0,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -390,17 +365,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -409,56 +384,22 @@ public class ContractsEditPageTests : BaseTest
         // Assert
         cut.Markup.ShouldContain("No products added yet");
     }
-
+    
     [Fact]
-    public void ContractsEdit_ContractNotFound_ShowsErrorMessage()
-    {
+    public void ContractsEdit_BackToListButton_NavigatesToContractsIndex() {
         // Arrange
         var contractId = Guid.NewGuid();
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Success<ContractModel>(null!));
-        
-        // Act
-        var cut = RenderComponent<Edit>(parameters => parameters
-            .Add(p => p.ContractId, contractId));
-        cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
-        
-        // Assert
-        cut.Markup.ShouldContain("Contract not found");
-    }
+        var contract = new ContractModels.ContractModel
+        {
+            ContractId = contractId,
+            Description = "Test Contract",
+            OperatorName = "Test Operator",
+            Products = new List<ContractModels.ContractProductModel>()
+        };
 
-    [Fact]
-    public void ContractsEdit_ContractNotFound_HasBackToListButton()
-    {
-        // Arrange
-        var contractId = Guid.NewGuid();
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Success<ContractModel>(null!));
-        
-        // Act
-        var cut = RenderComponent<Edit>(parameters => parameters
-            .Add(p => p.ContractId, contractId));
-        cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
-        
-        // Find Back to List button
-        IRefreshableElementCollection<IElement> buttons = cut.FindAll("button");
-        IElement? backButton = buttons.FirstOrDefault(b => b.TextContent.Contains("Back to List"));
-        
-        // Assert
-        backButton.ShouldNotBeNull();
-    }
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
+            .ReturnsAsync(Result.Success(contract));
 
-    [Fact]
-    public void ContractsEdit_BackToListButton_NavigatesToContractsIndex()
-    {
-        // Arrange
-        var contractId = Guid.NewGuid();
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Success<ContractModel>(null!));
-        
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -479,17 +420,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -518,29 +459,29 @@ public class ContractsEditPageTests : BaseTest
         // Arrange
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 0,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -570,24 +511,24 @@ public class ContractsEditPageTests : BaseTest
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
         var feeId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 1,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>
                     {
-                        new ContractProductTransactionFeeModel
+                        new ContractModels.ContractProductTransactionFeeModel
                         {
                             TransactionFeeId = feeId,
                             Description = "Fee 1",
@@ -599,10 +540,10 @@ public class ContractsEditPageTests : BaseTest
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -622,17 +563,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -648,17 +589,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -675,17 +616,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -717,17 +658,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -753,17 +694,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -789,29 +730,29 @@ public class ContractsEditPageTests : BaseTest
         // Arrange
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 0,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -844,29 +785,29 @@ public class ContractsEditPageTests : BaseTest
         // Arrange
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 0,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -893,29 +834,29 @@ public class ContractsEditPageTests : BaseTest
         // Arrange
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 0,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -935,24 +876,24 @@ public class ContractsEditPageTests : BaseTest
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
         var feeId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 1,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>
                     {
-                        new ContractProductTransactionFeeModel
+                        new ContractModels.ContractProductTransactionFeeModel
                         {
                             TransactionFeeId = feeId,
                             Description = "Fee 1",
@@ -964,10 +905,10 @@ public class ContractsEditPageTests : BaseTest
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -985,17 +926,17 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -1022,29 +963,29 @@ public class ContractsEditPageTests : BaseTest
         // Arrange
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 0,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -1070,39 +1011,39 @@ public class ContractsEditPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = Guid.NewGuid(),
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 0,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 },
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = Guid.NewGuid(),
                     ProductName = "Product 2",
                     DisplayText = "Display 2",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "200",
                     NumberOfFees = 0,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>()
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -1121,24 +1062,24 @@ public class ContractsEditPageTests : BaseTest
         // Arrange
         var contractId = Guid.NewGuid();
         var productId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = productId,
                     ProductName = "Product 1",
                     DisplayText = "Display 1",
-                    ProductType = "NotSet",
+                    ProductType = ProductType.NotSet,
                     Value = "100",
                     NumberOfFees = 2,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>
                     {
-                        new ContractProductTransactionFeeModel
+                        new ContractModels.ContractProductTransactionFeeModel
                         {
                             TransactionFeeId = Guid.NewGuid(),
                             Description = "Fee 1",
@@ -1146,22 +1087,22 @@ public class ContractsEditPageTests : BaseTest
                             CalculationType = 0,
                             FeeType = 0
                         },
-                        new ContractProductTransactionFeeModel
+                        new ContractModels.ContractProductTransactionFeeModel
                         {
                             TransactionFeeId = Guid.NewGuid(),
                             Description = "Fee 2",
                             Value = 2.5m,
-                            CalculationType = 1,
-                            FeeType = 1
+                            CalculationType = CalculationType.Fixed,
+                            FeeType = FeeType.Merchant
                         }
                     }
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<Edit>(parameters => parameters
             .Add(p => p.ContractId, contractId));

--- a/EstateManagementUI.BlazorServer.Tests/Pages/Contracts/ContractsNewPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Contracts/ContractsNewPageTests.cs
@@ -1,5 +1,7 @@
 using AngleSharp.Dom;
 using Bunit;
+using EstateManagementUI.BlazorServer.Models;
+using EstateManagementUI.BusinessLogic.BackendAPI.DataTransferObjects;
 using EstateManagementUI.BusinessLogic.Models;
 using EstateManagementUI.BusinessLogic.Requests;
 using Moq;
@@ -15,8 +17,7 @@ public class ContractsNewPageTests : BaseTest
     public void ContractsNew_RendersCorrectly()
     {
         // Arrange
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorDropDownModel>()));
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(new List<OperatorModels.OperatorDropDownModel>()));
 
         // Act
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
@@ -29,8 +30,7 @@ public class ContractsNewPageTests : BaseTest
     public void ContractsNew_HasCorrectPageTitle()
     {
         // Arrange
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorDropDownModel>()));
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(new List<OperatorModels.OperatorDropDownModel>()));
 
         // Act
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
@@ -44,8 +44,7 @@ public class ContractsNewPageTests : BaseTest
     public void ContractsNew_CancelButton_NavigatesToContractsIndex()
     {
         // Arrange
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorDropDownModel>()));
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(new List<OperatorModels.OperatorDropDownModel>()));
 
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
         cut.WaitForAssertion(() => cut.Markup.ShouldContain("Create New Contract"), timeout: TimeSpan.FromSeconds(5));
@@ -64,8 +63,7 @@ public class ContractsNewPageTests : BaseTest
     public void ContractsNew_CreateContractButton_IsPresent()
     {
         // Arrange
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorDropDownModel>()));
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(new List<OperatorModels.OperatorDropDownModel>()));
 
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
         cut.WaitForAssertion(() => cut.Markup.ShouldContain("Create New Contract"), timeout: TimeSpan.FromSeconds(5));
@@ -79,22 +77,20 @@ public class ContractsNewPageTests : BaseTest
     public void ContractsNew_LoadsOperatorsSuccessfully()
     {
         // Arrange
-        List<OperatorDropDownModel> operators = new List<OperatorDropDownModel>
+        List<OperatorModels.OperatorDropDownModel> operators = new List<OperatorModels.OperatorDropDownModel>
         {
-            new OperatorDropDownModel
+            new OperatorModels.OperatorDropDownModel
             {
                 OperatorId = Guid.NewGuid(),
                 OperatorName = "Test Operator 1"
             },
-            new OperatorDropDownModel
+            new OperatorModels.OperatorDropDownModel
             {
                 OperatorId = Guid.NewGuid(),
                 OperatorName = "Test Operator 2"
             }
         };
-
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(operators));
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(operators));
 
         // Act
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
@@ -105,11 +101,22 @@ public class ContractsNewPageTests : BaseTest
     }
 
     [Fact]
+    public void ContractsNew_LoadsOperatorsFailed_NavigateToError()
+    {
+        // Arrange
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Failure());
+
+        // Act
+        IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
+
+        _fakeNavigationManager.Uri.ShouldContain("error");
+    }
+
+    [Fact]
     public void ContractsNew_WithNoOperators_ShowsNoOperatorsMessage()
     {
         // Arrange
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(new List<OperatorDropDownModel>()));
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(new List<OperatorModels.OperatorDropDownModel>()));
 
         // Act
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
@@ -123,18 +130,17 @@ public class ContractsNewPageTests : BaseTest
     {
         // Arrange
         Guid operatorId = Guid.NewGuid();
-        List<OperatorDropDownModel> operators = new List<OperatorDropDownModel>
+        List<OperatorModels.OperatorDropDownModel> operators = new List<OperatorModels.OperatorDropDownModel>
         {
-            new OperatorDropDownModel
+            new OperatorModels.OperatorDropDownModel
             {
                 OperatorId = operatorId,
                 OperatorName = "Test Operator"
             }
         };
 
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(operators));
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractCommands.CreateContractCommand>(), default))
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(operators));
+        this.ContractUIService.Setup(c => c.CreateContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<ContractModels.CreateContractFormModel>()))
             .ReturnsAsync(Result.Success());
 
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
@@ -153,7 +159,6 @@ public class ContractsNewPageTests : BaseTest
 
         // Assert
         cut.WaitForAssertion(() => {
-            _mockMediator.Verify(x => x.Send(It.IsAny<ContractCommands.CreateContractCommand>(), default), Times.Once());
             _fakeNavigationManager.Uri.ShouldContain("/contracts");
         }, timeout: TimeSpan.FromSeconds(5));
     }
@@ -163,19 +168,18 @@ public class ContractsNewPageTests : BaseTest
     {
         // Arrange
         Guid operatorId = Guid.NewGuid();
-        List<OperatorDropDownModel> operators = new List<OperatorDropDownModel>
+        List<OperatorModels.OperatorDropDownModel> operators = new List<OperatorModels.OperatorDropDownModel>
         {
-            new OperatorDropDownModel
+            new OperatorModels.OperatorDropDownModel
             {
                 OperatorId = operatorId,
                 OperatorName = "Test Operator"
             }
         };
 
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(operators));
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractCommands.CreateContractCommand>(), default))
-            .ReturnsAsync(Result.Failure("Failed to create contract"));
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(operators));
+        this.ContractUIService.Setup(c => c.CreateContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<ContractModels.CreateContractFormModel>()))
+            .ReturnsAsync(Result.Failure);
 
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
         cut.WaitForAssertion(() => cut.Markup.ShouldContain("Test Operator"), timeout: TimeSpan.FromSeconds(5));
@@ -193,7 +197,6 @@ public class ContractsNewPageTests : BaseTest
 
         // Assert
         cut.WaitForAssertion(() => {
-            _mockMediator.Verify(x => x.Send(It.IsAny<ContractCommands.CreateContractCommand>(), default), Times.Once());
             cut.Markup.ShouldContain("Failed to create contract");
         }, timeout: TimeSpan.FromSeconds(5));
     }
@@ -203,17 +206,16 @@ public class ContractsNewPageTests : BaseTest
     {
         // Arrange
         Guid operatorId = Guid.NewGuid();
-        List<OperatorDropDownModel> operators = new List<OperatorDropDownModel>
+        List<OperatorModels.OperatorDropDownModel> operators = new List<OperatorModels.OperatorDropDownModel>
         {
-            new OperatorDropDownModel
+            new OperatorModels.OperatorDropDownModel
             {
                 OperatorId = operatorId,
                 OperatorName = "Test Operator"
             }
         };
 
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(operators));
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(operators));
 
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
         cut.WaitForAssertion(() => cut.Markup.ShouldContain("Test Operator"), timeout: TimeSpan.FromSeconds(5));
@@ -229,7 +231,6 @@ public class ContractsNewPageTests : BaseTest
         cut.WaitForAssertion(() => {
             cut.Markup.ShouldContain("Description is required");
             // Should not call the mediator
-            _mockMediator.Verify(x => x.Send(It.IsAny<ContractCommands.CreateContractCommand>(), default), Times.Never());
         }, timeout: TimeSpan.FromSeconds(5));
     }
 
@@ -237,17 +238,16 @@ public class ContractsNewPageTests : BaseTest
     public void ContractsNew_FormValidation_RequiresOperator()
     {
         // Arrange
-        List<OperatorDropDownModel> operators = new List<OperatorDropDownModel>
+        List<OperatorModels.OperatorDropDownModel> operators = new List<OperatorModels.OperatorDropDownModel>
         {
-            new OperatorDropDownModel
+            new OperatorModels.OperatorDropDownModel
             {
                 OperatorId = Guid.NewGuid(),
                 OperatorName = "Test Operator"
             }
         };
 
-        _mockMediator.Setup(x => x.Send(It.IsAny<OperatorQueries.GetOperatorsForDropDownQuery>(), default))
-            .ReturnsAsync(Result.Success(operators));
+        this.OperatorUIService.Setup(o => o.GetOperatorsForDropDown(It.IsAny<CorrelationId>(), It.IsAny<Guid>())).ReturnsAsync(Result.Success(operators));
 
         IRenderedComponent<ContractsNew> cut = RenderComponent<ContractsNew>();
         cut.WaitForAssertion(() => cut.Markup.ShouldContain("Test Operator"), timeout: TimeSpan.FromSeconds(5));
@@ -262,8 +262,6 @@ public class ContractsNewPageTests : BaseTest
         // Assert - Validation message should appear
         cut.WaitForAssertion(() => {
             cut.Markup.ShouldContain("Operator is required");
-            // Should not call the mediator
-            _mockMediator.Verify(x => x.Send(It.IsAny<ContractCommands.CreateContractCommand>(), default), Times.Never());
         }, timeout: TimeSpan.FromSeconds(5));
     }
 }

--- a/EstateManagementUI.BlazorServer.Tests/Pages/Contracts/ContractsViewPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Contracts/ContractsViewPageTests.cs
@@ -2,6 +2,7 @@ using AngleSharp.Dom;
 using Bunit;
 using EstateManagementUI.BlazorServer.Components.Pages.Contracts;
 using EstateManagementUI.BlazorServer.Components.Permissions;
+using EstateManagementUI.BlazorServer.Models;
 using EstateManagementUI.BlazorServer.Permissions;
 using EstateManagementUI.BlazorServer.Tests.Pages.FileProcessing;
 using EstateManagementUI.BusinessLogic.Models;
@@ -12,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Shouldly;
 using SimpleResults;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages.Contracts;
 
@@ -22,16 +24,16 @@ public class ContractsViewPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator"
         };
         
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -45,16 +47,16 @@ public class ContractsViewPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator"
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -69,9 +71,15 @@ public class ContractsViewPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Success(new ContractModel { ContractId = contractId }));
-        
+        var contract = new ContractModels.ContractModel
+        {
+            ContractId = contractId,
+            Description = "Test Contract",
+            OperatorName = "Test Operator"
+        };
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
+            .ReturnsAsync(Result.Success(contract));
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -86,16 +94,16 @@ public class ContractsViewPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator"
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -110,16 +118,16 @@ public class ContractsViewPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator"
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -140,28 +148,28 @@ public class ContractsViewPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = Guid.NewGuid(),
                     ProductName = "Test Product",
                     DisplayText = "Test Display",
-                    ProductType = "MobileTopup",
+                    ProductType = ProductType.MobileTopup,
                     Value = "100",
                     NumberOfFees = 2
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -178,17 +186,17 @@ public class ContractsViewPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>()
+            Products = new List<ContractModels.ContractProductModel>()
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -203,24 +211,24 @@ public class ContractsViewPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        var contract = new ContractModel
+        var contract = new ContractModels.ContractModel
         {
             ContractId = contractId,
             Description = "Test Contract",
             OperatorName = "Test Operator",
-            Products = new List<ContractProductModel>
+            Products = new List<ContractModels.ContractProductModel>
             {
-                new ContractProductModel
+                new ContractModels.ContractProductModel
                 {
                     ContractProductId = Guid.NewGuid(),
                     ProductName = "Test Product",
                     DisplayText = "Test Display",
-                    ProductType = "MobileTopup",
+                    ProductType = ProductType.MobileTopup,
                     Value = "100",
                     NumberOfFees = 1,
-                    TransactionFees = new List<ContractProductTransactionFeeModel>
+                    TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>
                     {
-                        new ContractProductTransactionFeeModel
+                        new ContractModels.ContractProductTransactionFeeModel
                         {
                             TransactionFeeId = Guid.NewGuid(),
                             Description = "Service Fee",
@@ -232,10 +240,10 @@ public class ContractsViewPageTests : BaseTest
                 }
             }
         };
-        
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
+
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ReturnsAsync(Result.Success(contract));
-        
+
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.ContractId, contractId));
@@ -252,72 +260,15 @@ public class ContractsViewPageTests : BaseTest
     {
         // Arrange
         var contractId = Guid.NewGuid();
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Failure("Failed to load contract"));
-        
-        // Act
-        var cut = RenderComponent<View>(parameters => parameters
-            .Add(p => p.ContractId, contractId));
-        cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
-        
-        // Assert
-        cut.Markup.ShouldContain("Contract not found");
-    }
+        this.ContractUIService.Setup(c => c.GetContract(It.IsAny<CorrelationId>(), It.IsAny<Guid>(), It.IsAny<Guid>()))
+            .ReturnsAsync(Result.Failure());
 
-    [Fact]
-    public void ContractsView_LoadContract_ReturnsNull_ShowsNotFoundMessage()
-    {
-        // Arrange
-        var contractId = Guid.NewGuid();
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Success<ContractModel>(null!));
-        
         // Act
         var cut = RenderComponent<View>(parameters => parameters
             .Add(p => p.ContractId, contractId));
-        cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
-        
-        // Assert
-        cut.Markup.ShouldContain("Contract not found");
-    }
+        //cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
 
-    [Fact]
-    public void ContractsView_ContractNotFound_HasBackButton()
-    {
-        // Arrange
-        var contractId = Guid.NewGuid();
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Success<ContractModel>(null!));
-        
-        // Act
-        var cut = RenderComponent<View>(parameters => parameters
-            .Add(p => p.ContractId, contractId));
-        cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
-        
         // Assert
-        cut.Markup.ShouldContain("Back to List");
-    }
-
-    [Fact]
-    public void ContractsView_ContractNotFound_BackButton_NavigatesToContractsList()
-    {
-        // Arrange
-        var contractId = Guid.NewGuid();
-        _mockMediator.Setup(x => x.Send(It.IsAny<ContractQueries.GetContractQuery>(), default))
-            .ReturnsAsync(Result.Success<ContractModel>(null!));
-        
-        // Act
-        var cut = RenderComponent<View>(parameters => parameters
-            .Add(p => p.ContractId, contractId));
-        cut.WaitForState(() => !cut.Markup.Contains("animate-spin"), TimeSpan.FromSeconds(5));
-        
-        // Find and click the Back to List button
-        IRefreshableElementCollection<IElement> buttons = cut.FindAll("button");
-        IElement? backButton = buttons.FirstOrDefault(b => b.TextContent.Contains("Back to List"));
-        backButton.ShouldNotBeNull();
-        backButton.Click();
-        
-        // Assert
-        _fakeNavigationManager.Uri.ShouldContain("/contracts");
+        _fakeNavigationManager.Uri.ShouldContain("error");
     }
 }

--- a/EstateManagementUI.BlazorServer.Tests/UIServices/ContractUIServiceTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/UIServices/ContractUIServiceTests.cs
@@ -1,0 +1,349 @@
+﻿using EstateManagementUI.BlazorServer.Models;
+using EstateManagementUI.BlazorServer.UIServices;
+using EstateManagementUI.BusinessLogic.Requests;
+using MediatR;
+using Moq;
+using Shouldly;
+using SimpleResults;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EstateManagementUI.BlazorServer.Tests.UIServices
+{
+    public class ContractUIServiceTests
+    {
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly ContractUIService _service;
+
+        public ContractUIServiceTests()
+        {
+            _mockMediator = new Mock<IMediator>();
+            _service = new ContractUIService(_mockMediator.Object);
+        }
+
+        [Fact]
+        public async Task GetContracts_ReturnsMappedList_WhenMediatorSucceeds()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var correlationId = CorrelationIdHelper.New();
+
+            var bizContracts = new List<BusinessLogic.Models.ContractModel>
+            {
+                new()
+                {
+                    ContractId = Guid.NewGuid(),
+                    Description = "Contract A",
+                    OperatorId = Guid.NewGuid(),
+                    OperatorName = "OpA",
+                    Products = new List<BusinessLogic.Models.ContractProductModel>
+                    {
+                        new()
+                        {
+                            ContractProductId = Guid.NewGuid(),
+                            ProductName = "Prod1",
+                            DisplayText = "Prod 1",
+                            ProductType = "NotSet",
+                            Value = "10.00",
+                            NumberOfFees = 0,
+                            TransactionFees = new List<BusinessLogic.Models.ContractProductTransactionFeeModel>()
+                        }
+                    }
+                }
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractQueries.GetContractsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success(bizContracts));
+
+            // Act
+            var result = await _service.GetContracts(correlationId, estateId);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            result.Data.ShouldNotBeNull();
+            result.Data!.Count.ShouldBe(1);
+            var mapped = result.Data.First();
+            mapped.ContractId.ShouldBe(bizContracts[0].ContractId);
+            mapped.Description.ShouldBe("Contract A");
+            mapped.OperatorName.ShouldBe("OpA");
+            mapped.Products.ShouldNotBeNull();
+            mapped.Products!.Count.ShouldBe(1);
+            mapped.Products![0].ProductName.ShouldBe("Prod1");
+        }
+
+        [Fact]
+        public async Task GetContracts_ReturnsFailure_WhenMediatorFails()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractQueries.GetContractsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure("err"));
+
+            // Act
+            var result = await _service.GetContracts(CorrelationIdHelper.New(), Guid.NewGuid());
+
+            // Assert
+            result.IsFailed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task GetContract_ReturnsMappedModel_WhenMediatorSucceeds()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var contractId = Guid.NewGuid();
+            var bizContract = new BusinessLogic.Models.ContractModel
+            {
+                ContractId = contractId,
+                Description = "Contract Detail",
+                OperatorId = Guid.NewGuid(),
+                OperatorName = "OpDetail",
+                Products = new List<BusinessLogic.Models.ContractProductModel>()
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractQueries.GetContractQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success(bizContract));
+
+            // Act
+            var result = await _service.GetContract(CorrelationIdHelper.New(), estateId, contractId);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            var model = result.Data!;
+            model.ContractId.ShouldBe(contractId);
+            model.Description.ShouldBe("Contract Detail");
+            model.OperatorName.ShouldBe("OpDetail");
+        }
+
+        [Fact]
+        public async Task GetContract_ReturnsFailure_WhenMediatorFails()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractQueries.GetContractQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure("nf"));
+
+            // Act
+            var result = await _service.GetContract(CorrelationIdHelper.New(), Guid.NewGuid(), Guid.NewGuid());
+
+            // Assert
+            result.IsFailed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task AddProductToContract_SendsCommand_WithValue_WhenNotVariable()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var contractId = Guid.NewGuid();
+
+            var productModel = new ContractModels.AddProductModel
+            {
+                ProductName = "P1",
+                DisplayText = "P One",
+                IsVariableValue = false,
+                Value = 12.34m
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractCommands.AddProductToContractCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success);
+
+            // Act
+            var result = await _service.AddProductToContract(CorrelationIdHelper.New(), estateId, contractId, productModel);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            _mockMediator.Verify(m => m.Send(It.Is<ContractCommands.AddProductToContractCommand>(c =>
+                c.EstateId == estateId &&
+                c.ContractId == contractId &&
+                c.ProductName == productModel.ProductName &&
+                c.DisplayText == productModel.DisplayText &&
+                c.Value.HasValue && c.Value.Value == productModel.Value
+            ), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddProductToContract_SendsCommand_NullValue_WhenVariable()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var contractId = Guid.NewGuid();
+
+            var productModel = new ContractModels.AddProductModel
+            {
+                ProductName = "P2",
+                DisplayText = "P Two",
+                IsVariableValue = true,
+                Value = 99.99m
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractCommands.AddProductToContractCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success);
+
+            // Act
+            var result = await _service.AddProductToContract(CorrelationIdHelper.New(), estateId, contractId, productModel);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            _mockMediator.Verify(m => m.Send(It.Is<ContractCommands.AddProductToContractCommand>(c =>
+                c.EstateId == estateId &&
+                c.ContractId == contractId &&
+                c.ProductName == productModel.ProductName &&
+                c.DisplayText == productModel.DisplayText &&
+                c.Value == null
+            ), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddProductToContract_ReturnsFailure_WhenMediatorFails()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractCommands.AddProductToContractCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure);
+
+            // Act
+            var result = await _service.AddProductToContract(CorrelationIdHelper.New(), Guid.NewGuid(), Guid.NewGuid(), new ContractModels.AddProductModel { ProductName = "x", DisplayText = "y", IsVariableValue = false, Value = 1m });
+
+            // Assert
+            result.IsFailed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task AddTransactionFeeToProduct_SendsCorrectCommand()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var contractId = Guid.NewGuid();
+            var contractProductId = Guid.NewGuid();
+
+            var feeModel = new ContractModels.AddTransactionFeeModel
+            {
+                Description = "Fee A",
+                FeeValue = 2.50m,
+                CalculationType = "Fixed",
+                FeeType = "Charge"
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractCommands.AddTransactionFeeToProductCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success);
+
+            // Act
+            var result = await _service.AddTransactionFeeToProduct(CorrelationIdHelper.New(), estateId, contractId, contractProductId, feeModel);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            _mockMediator.Verify(m => m.Send(It.Is<ContractCommands.AddTransactionFeeToProductCommand>(c =>
+                c.EstateId == estateId &&
+                c.ContractId == contractId &&
+                c.ProductId == contractProductId &&
+                c.Description == feeModel.Description &&
+                c.Value == feeModel.FeeValue.Value &&
+                c.CalculationType == feeModel.CalculationType &&
+                c.FeeType == feeModel.FeeType
+            ), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddTransactionFeeToProduct_ReturnsFailure_WhenMediatorFails()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractCommands.AddTransactionFeeToProductCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure);
+
+            // Act
+            var result = await _service.AddTransactionFeeToProduct(CorrelationIdHelper.New(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), new ContractModels.AddTransactionFeeModel { Description = "d", FeeValue = 1m, CalculationType = "c", FeeType = "f" });
+
+            // Assert
+            result.IsFailed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task RemoveTransactionFeeFromProduct_SendsCorrectCommand()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var contractId = Guid.NewGuid();
+            var contractProductId = Guid.NewGuid();
+            var transactionFeeId = Guid.NewGuid();
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractCommands.RemoveTransactionFeeFromProductCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success);
+
+            // Act
+            var result = await _service.RemoveTransactionFeeFromProduct(CorrelationIdHelper.New(), estateId, contractId, contractProductId, transactionFeeId);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task RemoveTransactionFeeFromProduct_ReturnsFailure_WhenMediatorFails()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractCommands.RemoveTransactionFeeFromProductCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure);
+
+            // Act
+            var result = await _service.RemoveTransactionFeeFromProduct(CorrelationIdHelper.New(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+            // Assert
+            result.IsFailed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task CreateContract_SendsCreateCommand_WithParsedOperatorId()
+        {
+            // Arrange
+            var estateId = Guid.NewGuid();
+            var operatorId = Guid.NewGuid();
+            var createModel = new ContractModels.CreateContractFormModel
+            {
+                Description = "New Contract",
+                OperatorId = operatorId.ToString()
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractCommands.CreateContractCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success);
+            
+            // Act
+            var result = await _service.CreateContract(CorrelationIdHelper.New(), estateId, createModel);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            _mockMediator.Verify(m => m.Send(It.Is<ContractCommands.CreateContractCommand>(c =>
+                c.EstateId == estateId &&
+                c.Description == createModel.Description &&
+                c.OperatorId == operatorId
+            ), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateContract_ReturnsFailure_WhenMediatorFails()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<ContractCommands.CreateContractCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure);
+
+            // Act
+            var result = await _service.CreateContract(CorrelationIdHelper.New(), Guid.NewGuid(), new ContractModels.CreateContractFormModel { Description = "x", OperatorId = Guid.NewGuid().ToString() });
+
+            // Assert
+            result.IsFailed.ShouldBeTrue();
+        }
+    }
+}

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor
@@ -4,8 +4,9 @@
 @using System.ComponentModel.DataAnnotations
 @using EstateManagementUI.BlazorServer.Factories
 @using EstateManagementUI.BlazorServer.Permissions
+@using EstateManagementUI.BlazorServer.UIServices
 @using EstateManagementUI.BusinessLogic.Requests
-@inject IMediator Mediator
+@inject IContractUIService ContractUiService
 @inject NavigationManager NavigationManager
 @inject IPermissionService PermissionService
 
@@ -26,8 +27,8 @@
                 <h1 class="text-2xl font-bold text-gray-900">Edit Contract: @contractModel.Description</h1>
             </div>
             <div class="flex space-x-2">
-                <button class="btn btn-secondary" @onclick="BackToView">
-                    Cancel
+                <button class="btn btn-secondary" @onclick="BackToList">
+                    Back to List
                 </button>
             </div>
         </div>
@@ -73,9 +74,6 @@
                 </div>
 
                 <div class="flex justify-end space-x-4 pt-4 border-t">
-                    <button type="button" class="btn btn-secondary" @onclick="BackToView" disabled="@isSaving">
-                        Cancel
-                    </button>
                     <button type="submit" class="btn btn-primary" disabled="@isSaving">
                         @if (isSaving)
                         {

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Edit.razor.cs
@@ -1,314 +1,201 @@
 ﻿using EstateManagementUI.BlazorServer.Factories;
+using EstateManagementUI.BlazorServer.Models;
 using EstateManagementUI.BlazorServer.Permissions;
 using EstateManagementUI.BusinessLogic.Requests;
+using MediatR;
 using Microsoft.AspNetCore.Components;
+using Shared.Results;
+using SimpleResults;
 using System.ComponentModel.DataAnnotations;
-using EstateManagementUI.BlazorServer.Models;
 
-namespace EstateManagementUI.BlazorServer.Components.Pages.Contracts
+namespace EstateManagementUI.BlazorServer.Components.Pages.Contracts;
+
+public partial class Edit
 {
-    public partial class Edit
+    [Parameter]
+    public Guid ContractId { get; set; }
+
+    private ContractModels.ContractModel? contractModel;
+    private ContractModels.EditContractModel model = new();
+    private bool isLoading = true;
+    private bool isSaving = false;
+
+    // Product modal state
+    private bool showAddProductModal = false;
+    private bool isAddingProduct = false;
+    private ContractModels.AddProductModel productModel = new();
+    private string? productErrorMessage;
+
+    // Transaction fee modal state
+    private bool showAddFeeModal = false;
+    private bool isAddingFee = false;
+    private ContractModels.AddTransactionFeeModel feeModel = new();
+    private string? feeErrorMessage;
+    private Guid currentProductId;
+
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        [Parameter]
-        public Guid ContractId { get; set; }
-
-        private ContractModel? contractModel;
-        private EditContractModel model = new();
-        private bool isLoading = true;
-        private bool isSaving = false;
-        private bool hasPermission = false;
-        private string? errorMessage;
-        private string? successMessage;
-
-        // Product modal state
-        private bool showAddProductModal = false;
-        private bool isAddingProduct = false;
-        private AddProductModel productModel = new();
-        private string? productErrorMessage;
-
-        // Transaction fee modal state
-        private bool showAddFeeModal = false;
-        private bool isAddingFee = false;
-        private AddTransactionFeeModel feeModel = new();
-        private string? feeErrorMessage;
-        private Guid currentProductId;
-
-
-        protected override async Task OnAfterRenderAsync(bool firstRender)
-        {
-            if (!firstRender)
-            {
-                await base.OnAfterRenderAsync(firstRender);
-                return;
-            }
-            await RequirePermission(PermissionSection.Contract, PermissionFunction.Edit);
-            await LoadContract();
+        if (!firstRender) {
+            return;
         }
 
-        private async Task LoadContract()
-        {
-            try
-            {
-                isLoading = true;
-                Guid estateId = await GetEstateId();
-                var result = await Mediator.Send(new ContractQueries.GetContractQuery(CorrelationIdHelper.New(), estateId, ContractId));
-
-                if (result.IsSuccess && result.Data != null)
-                {
-                    contractModel = ModelFactory.ConvertFrom(result.Data);
-
-                    // Initialize model with current values
-                    model = new EditContractModel
-                    {
-                        Description = contractModel.Description
-                    };
-                }
-            }
-            finally
-            {
-                isLoading = false;
-                StateHasChanged();
-            }
+        Result result = await OnAfterRender(PermissionSection.Contract, PermissionFunction.Edit, this.LoadContract);
+        if (result.IsFailed) {
+            return;
         }
 
-        private async Task HandleSubmit()
-        {
-            isSaving = true;
-            ClearMessages();
+        isLoading = false;
+        this.StateHasChanged();
+    }
 
-            try
-            {
-                // Note: Update contract description endpoint is not currently implemented in the backend
-                // This form is present for future implementation
-                errorMessage = "Contract description update is not yet supported by the backend API";
-            }
-            catch (Exception ex)
-            {
-                errorMessage = $"An error occurred: {ex.Message}";
-            }
-            finally
-            {
-                isSaving = false;
-            }
+    private async Task<Result> LoadContract() {
+        isLoading = true;
+        Guid estateId = await GetEstateId();
+        var result = await this.ContractUiService.GetContract(CorrelationIdHelper.New(), estateId, ContractId);
+
+        if (result.IsFailed) {
+            return ResultHelpers.CreateFailure(result);
         }
 
-        private void ShowAddProductModal()
-        {
-            productModel = new AddProductModel();
-            productErrorMessage = null;
-            showAddProductModal = true;
+        contractModel = result.Data;
+
+        // Initialize model with current values
+        model = new ContractModels.EditContractModel { Description = contractModel.Description };
+        return Result.Success();
+    }
+
+    private async Task HandleSubmit()
+    {
+        isSaving = true;
+        
+        // Note: Update contract description endpoint is not currently implemented in the backend
+        // This form is present for future implementation
+        errorMessage = "Contract description update is not yet supported by the backend API";
+        isSaving = false;
+    }
+
+    private void ShowAddProductModal()
+    {
+        productModel = new ContractModels.AddProductModel();
+        productErrorMessage = null;
+        showAddProductModal = true;
+    }
+
+    private void CloseAddProductModal()
+    {
+        showAddProductModal = false;
+        productModel = new ContractModels.AddProductModel();
+        productErrorMessage = null;
+    }
+
+    private async Task HandleAddProduct()
+    {
+        isAddingProduct = true;
+        productErrorMessage = null;
+
+        var estateId = await this.GetEstateId();
+
+        var result = await this.ContractUiService.AddProductToContract(CorrelationIdHelper.New(), estateId, this.ContractId, this.productModel);
+
+        if (result.IsSuccess) {
+            successMessage = "Product added successfully";
+            CloseAddProductModal();
+        }
+        else {
+            productErrorMessage = "Failed to add product";
         }
 
-        private void CloseAddProductModal()
-        {
-            showAddProductModal = false;
-            productModel = new AddProductModel();
-            productErrorMessage = null;
+        await this.WaitOnUIRefresh();
+
+        await LoadContract();
+
+        StateHasChanged();
+        isAddingProduct = false;
+    }
+
+    private void ShowAddFeeModal(Guid productId)
+    {
+        currentProductId = productId;
+        feeModel = new ContractModels.AddTransactionFeeModel();
+        feeErrorMessage = null;
+        showAddFeeModal = true;
+    }
+
+    private void CloseAddFeeModal()
+    {
+        showAddFeeModal = false;
+        feeModel = new ContractModels.AddTransactionFeeModel();
+        feeErrorMessage = null;
+        currentProductId = Guid.Empty;
+    }
+
+    private async Task HandleAddFee() {
+        isAddingFee = true;
+        feeErrorMessage = null;
+
+        var estateId = await this.GetEstateId();
+
+        var result = await this.ContractUiService.AddTransactionFeeToProduct(CorrelationIdHelper.New(), estateId, this.ContractId, this.currentProductId, this.feeModel);
+
+        if (result.IsSuccess) {
+            successMessage = "Transaction fee added successfully";
+            CloseAddProductModal();
+        }
+        else {
+            productErrorMessage = "Failed to transaction fee";
         }
 
-        private async Task HandleAddProduct()
+        await this.WaitOnUIRefresh();
+
+        await LoadContract();
+
+        StateHasChanged();
+    }
+
+    private async Task RemoveProduct(Guid productId)
+    {
+        //if (contractModel == null || contractModel.Products == null) return;
+
+        //var product = contractModel.Products.FirstOrDefault(p => p.ContractProductId == productId);
+        //if (product != null)
+        //{
+        // Note: Backend API for product removal not yet implemented
+        // For now, show a message to the user
+        errorMessage = "Product removal is not yet supported by the backend API. This feature will be available once the backend endpoint is implemented.";
+        //}
+    }
+
+    private async Task RemoveFee(Guid productId, Guid feeId)
+    {
+        var estateId = await this.GetEstateId();
+
+        var result = await this.ContractUiService.RemoveTransactionFeeFromProduct(CorrelationIdHelper.New(), estateId, this.ContractId, productId, feeId);
+
+        if (result.IsSuccess)
         {
-            isAddingProduct = true;
-            productErrorMessage = null;
-
-            try {
-                var estateId = await this.GetEstateId();
-
-                var command = new ContractCommands.AddProductToContractCommand(
-                    CorrelationIdHelper.New(),
-                    estateId,
-                    ContractId,
-                    productModel.ProductName!,
-                    productModel.DisplayText!,
-                    productModel.IsVariableValue ? null : productModel.Value
-                );
-
-                var result = await Mediator.Send(command);
-
-                if (result.IsSuccess)
-                {
-                    successMessage = "Product added successfully";
-                    CloseAddProductModal();
-                    
-                    // Small delay so user sees confirmation (adjust duration as needed)
-                    await this.WaitOnUIRefresh();
-
-                    await LoadContract();
-
-                    StateHasChanged();
-
-                }
-                else
-                {
-                    productErrorMessage = result.Message ?? "Failed to add product";
-                }
-            }
-            catch (Exception ex)
-            {
-                productErrorMessage = $"An error occurred: {ex.Message}";
-            }
-            finally
-            {
-                isAddingProduct = false;
-            }
+            successMessage = "Transaction fee removed successfully";
+            CloseAddProductModal();
+        }
+        else
+        {
+            productErrorMessage = "Failed to remove transaction fee";
         }
 
-        private void ShowAddFeeModal(Guid productId)
-        {
-            currentProductId = productId;
-            feeModel = new AddTransactionFeeModel();
-            feeErrorMessage = null;
-            showAddFeeModal = true;
-        }
+        await this.WaitOnUIRefresh();
 
-        private void CloseAddFeeModal()
-        {
-            showAddFeeModal = false;
-            feeModel = new AddTransactionFeeModel();
-            feeErrorMessage = null;
-            currentProductId = Guid.Empty;
-        }
+        await LoadContract();
 
-        private async Task HandleAddFee()
-        {
-            isAddingFee = true;
-            feeErrorMessage = null;
+        StateHasChanged();
+    }
 
-            try {
-                var estateId = await this.GetEstateId();
+    private void BackToView()
+    {
+        NavigationManager.NavigateTo($"/contracts/{ContractId}");
+    }
 
-                var command = new ContractCommands.AddTransactionFeeToProductCommand(
-                    CorrelationIdHelper.New(),
-                    estateId,
-                    ContractId,
-                    currentProductId,
-                    feeModel.Description!,
-                    feeModel.FeeValue!.Value,
-                    this.feeModel.CalculationType,
-                    this.feeModel.FeeType
-                );
-
-                var result = await Mediator.Send(command);
-
-                if (result.IsSuccess)
-                {
-                    successMessage = "Transaction fee added successfully";
-                    CloseAddFeeModal();
-
-                    // Small delay so user sees confirmation (adjust duration as needed)
-                    await this.WaitOnUIRefresh();
-
-                    await LoadContract();
-
-                    StateHasChanged();
-                }
-                else
-                {
-                    feeErrorMessage = result.Message ?? "Failed to add transaction fee";
-                }
-            }
-            catch (Exception ex)
-            {
-                feeErrorMessage = $"An error occurred: {ex.Message}";
-            }
-            finally
-            {
-                isAddingFee = false;
-            }
-        }
-
-        private void ClearMessages()
-        {
-            errorMessage = null;
-            successMessage = null;
-        }
-
-        private async Task RemoveProduct(Guid productId)
-        {
-            //if (contractModel == null || contractModel.Products == null) return;
-
-            //var product = contractModel.Products.FirstOrDefault(p => p.ContractProductId == productId);
-            //if (product != null)
-            //{
-                // Note: Backend API for product removal not yet implemented
-                // For now, show a message to the user
-                errorMessage = "Product removal is not yet supported by the backend API. This feature will be available once the backend endpoint is implemented.";
-            //}
-        }
-
-        private async Task RemoveFee(Guid productId, Guid feeId)
-        {
-            var estateId = await this.GetEstateId();
-
-            var command = new ContractCommands.RemoveTransactionFeeFromProductCommand(
-                CorrelationIdHelper.New(),
-                estateId,
-                ContractId,
-                productId, feeId
-            );
-
-            var result = await Mediator.Send(command);
-
-            if (result.IsSuccess)
-            {
-                successMessage = "Transaction fee removed successfully";
-
-                // Small delay so user sees confirmation (adjust duration as needed)
-                await this.WaitOnUIRefresh();
-
-                await LoadContract();
-            }
-            else
-            {
-                feeErrorMessage = result.Message ?? "Failed to remove transaction fee";
-            }
-
-            StateHasChanged();
-        }
-
-        private void BackToView()
-        {
-            NavigationManager.NavigateTo($"/contracts/{ContractId}");
-        }
-
-        private void BackToList()
-        {
-            NavigationManager.NavigateTo("/contracts");
-        }
-
-        public class EditContractModel
-        {
-            [Required(ErrorMessage = "Description is required")]
-            public string? Description { get; set; }
-        }
-
-        public class AddProductModel
-        {
-            [Required(ErrorMessage = "Product name is required")]
-            public string? ProductName { get; set; }
-
-            [Required(ErrorMessage = "Display text is required")]
-            public string? DisplayText { get; set; }
-
-            public bool IsVariableValue { get; set; }
-
-            public decimal? Value { get; set; }
-        }
-
-        public class AddTransactionFeeModel
-        {
-            [Required(ErrorMessage = "Description is required")]
-            public string? Description { get; set; }
-
-            [Required(ErrorMessage = "Calculation type is required")]
-            public string? CalculationType { get; set; }
-
-            [Required(ErrorMessage = "Fee type is required")]
-            public string? FeeType { get; set; }
-
-            [Required(ErrorMessage = "Fee value is required")]
-            [Range(0.01, double.MaxValue, ErrorMessage = "Fee value must be greater than 0")]
-            public decimal? FeeValue { get; set; }
-        }
+    private void BackToList()
+    {
+        NavigationManager.NavigateTo("/contracts");
     }
 }

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Index.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/Index.razor
@@ -3,8 +3,9 @@
 @rendermode InteractiveServer
 @inherits AuthorizedComponentBase
 @using EstateManagementUI.BlazorServer.Permissions
+@using EstateManagementUI.BlazorServer.UIServices
 @using EstateManagementUI.BusinessLogic.Requests
-@inject IMediator Mediator
+@inject IContractUIService ContractUiService
 @inject NavigationManager NavigationManager
 @inject IPermissionKeyProvider PermissionKeyProvider
 

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/New.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/New.razor
@@ -1,13 +1,10 @@
 @page "/contracts/new"
 @rendermode InteractiveServer
 @inherits AuthorizedComponentBase
-@using System.ComponentModel.DataAnnotations
-@using EstateManagementUI.BlazorServer.Factories
-@using EstateManagementUI.BlazorServer.Permissions
-@using EstateManagementUI.BusinessLogic.Requests
-@inject IMediator Mediator
+@using EstateManagementUI.BlazorServer.UIServices
+@inject IOperatorUIService OperatorUiService
+@inject IContractUIService ContractUiService
 @inject NavigationManager NavigationManager
-@inject IPermissionService PermissionService
 
 <PageTitle>Create New Contract</PageTitle>
 

--- a/EstateManagementUI.BlazorServer/Components/Pages/Contracts/View.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Contracts/View.razor
@@ -1,9 +1,10 @@
 @page "/contracts/{ContractId:guid}"
 @using EstateManagementUI.BlazorServer.Factories
+@using EstateManagementUI.BlazorServer.UIServices
 @using EstateManagementUI.BusinessLogic.Requests
 @rendermode InteractiveServer
 @inherits AuthorizedComponentBase
-@inject IMediator Mediator
+@inject IContractUIService ContractUiService
 @inject NavigationManager NavigationManager
 
 <PageTitle>View Contract</PageTitle>

--- a/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Edit.razor.cs
@@ -40,7 +40,7 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Merchants
         private string? terminalNumberError;
 
         // Contracts
-        private List<ContractDropDownModel>? availableContracts;
+        private List<ContractModels.ContractDropDownModel>? availableContracts;
         private List<MerchantContractModel> assignedContracts = new();
         private bool showAddContract = false;
         private string? selectedContractId;

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
@@ -5,7 +5,7 @@
 @using EstateManagementUI.BlazorServer.Components.Shared
 @using EstateManagementUI.BusinessLogic.Models
 @using EstateManagementUI.BusinessLogic.Requests
-@using ContractProductModel = EstateManagementUI.BlazorServer.Models.ContractProductModel
+@using ContractProductModel = EstateManagementUI.BlazorServer.Models.ContractModels.ContractProductModel
 @using MerchantDropDownModel = EstateManagementUI.BlazorServer.Models.MerchantDropDownModel
 @using MerchantModel = EstateManagementUI.BlazorServer.Models.MerchantModel
 @using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorDropDownModel

--- a/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
+++ b/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
@@ -1,11 +1,11 @@
 ﻿using EstateManagementUI.BusinessLogic.Models;
 using TransactionProcessor.DataTransferObjects.Responses.Contract;
 using ComparisonDateModel = EstateManagementUI.BlazorServer.Models.ComparisonDateModel;
-using ContractDropDownModel = EstateManagementUI.BlazorServer.Models.ContractDropDownModel;
+using ContractDropDownModel = EstateManagementUI.BlazorServer.Models.ContractModels.ContractDropDownModel;
 using OperatorDropDownModel = EstateManagementUI.BlazorServer.Models.OperatorModels.OperatorDropDownModel;
-using ContractModel = EstateManagementUI.BlazorServer.Models.ContractModel;
-using ContractProductModel = EstateManagementUI.BlazorServer.Models.ContractProductModel;
-using ContractProductTransactionFeeModel = EstateManagementUI.BlazorServer.Models.ContractProductTransactionFeeModel;
+using ContractModel = EstateManagementUI.BlazorServer.Models.ContractModels.ContractModel;
+using ContractProductModel = EstateManagementUI.BlazorServer.Models.ContractModels.ContractProductModel;
+using ContractProductTransactionFeeModel = EstateManagementUI.BlazorServer.Models.ContractModels.ContractProductTransactionFeeModel;
 using FileDetailsModel = EstateManagementUI.BlazorServer.Models.FileDetailsModel;
 using FileImportLogModel = EstateManagementUI.BlazorServer.Models.FileImportLogModel;
 using MerchantContractModel = EstateManagementUI.BlazorServer.Models.MerchantContractModel;

--- a/EstateManagementUI.BlazorServer/Models/ContractModels.cs
+++ b/EstateManagementUI.BlazorServer/Models/ContractModels.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel.DataAnnotations;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
+
+namespace EstateManagementUI.BlazorServer.Models;
+
+public class ContractModels {
+    public class ContractDropDownModel
+    {
+        public Guid ContractId { get; set; }
+        public string? Description { get; set; }
+        public string? OperatorName { get; set; }
+    }
+
+    // Contract Models
+    public class ContractModel
+    {
+        public Guid ContractId { get; set; }
+        public string? Description { get; set; }
+        public string? OperatorName { get; set; }
+        public Guid OperatorId { get; set; }
+        public List<ContractProductModel>? Products { get; set; }
+    }
+
+    public class ContractProductModel
+    {
+        public Guid ContractProductId { get; set; }
+        public string? ProductName { get; set; }
+        public string? DisplayText { get; set; }
+        public ProductType ProductType { get; set; }
+        // Changed from decimal? to string? to support displaying "Variable" for variable-value products
+        // This aligns with how the backend represents variable vs fixed value products
+        public string? Value { get; set; }
+        public int NumberOfFees { get; set; }
+        public List<ContractProductTransactionFeeModel>? TransactionFees { get; set; }
+    }
+
+    public class ContractProductTransactionFeeModel
+    {
+        public Guid TransactionFeeId { get; set; }
+        public string? Description { get; set; }
+        public CalculationType CalculationType { get; set; }
+        public FeeType FeeType { get; set; }
+        public decimal Value { get; set; }
+    }
+
+    public class EditContractModel
+    {
+        [Required(ErrorMessage = "Description is required")]
+        public string? Description { get; set; }
+    }
+
+    public class AddProductModel
+    {
+        [Required(ErrorMessage = "Product name is required")]
+        public string? ProductName { get; set; }
+
+        [Required(ErrorMessage = "Display text is required")]
+        public string? DisplayText { get; set; }
+
+        public bool IsVariableValue { get; set; }
+
+        public decimal? Value { get; set; }
+    }
+
+    public class AddTransactionFeeModel
+    {
+        [Required(ErrorMessage = "Description is required")]
+        public string? Description { get; set; }
+
+        [Required(ErrorMessage = "Calculation type is required")]
+        public string? CalculationType { get; set; }
+
+        [Required(ErrorMessage = "Fee type is required")]
+        public string? FeeType { get; set; }
+
+        [Required(ErrorMessage = "Fee value is required")]
+        [Range(0.01, double.MaxValue, ErrorMessage = "Fee value must be greater than 0")]
+        public decimal? FeeValue { get; set; }
+    }
+
+    public class CreateContractFormModel
+    {
+        [Required(ErrorMessage = "Description is required")]
+        public string? Description { get; set; }
+
+        [Required(ErrorMessage = "Operator is required")]
+        public string? OperatorId { get; set; }
+    }
+}

--- a/EstateManagementUI.BlazorServer/Models/Models.cs
+++ b/EstateManagementUI.BlazorServer/Models/Models.cs
@@ -1,5 +1,3 @@
-using TransactionProcessor.DataTransferObjects.Responses.Contract;
-
 namespace EstateManagementUI.BlazorServer.Models;
 
 public record EstateModel(Guid EstateId, string? EstateName, string? Reference) {
@@ -37,44 +35,7 @@ public class MerchantModel
 
 // Operator Models
 
-public class ContractDropDownModel
-{
-    public Guid ContractId { get; set; }
-    public string? Description { get; set; }
-    public string? OperatorName { get; set; }
-}
 
-// Contract Models
-public class ContractModel
-{
-    public Guid ContractId { get; set; }
-    public string? Description { get; set; }
-    public string? OperatorName { get; set; }
-    public Guid OperatorId { get; set; }
-    public List<ContractProductModel>? Products { get; set; }
-}
-
-public class ContractProductModel
-{
-    public Guid ContractProductId { get; set; }
-    public string? ProductName { get; set; }
-    public string? DisplayText { get; set; }
-    public ProductType ProductType { get; set; }
-    // Changed from decimal? to string? to support displaying "Variable" for variable-value products
-    // This aligns with how the backend represents variable vs fixed value products
-    public string? Value { get; set; }
-    public int NumberOfFees { get; set; }
-    public List<ContractProductTransactionFeeModel>? TransactionFees { get; set; }
-}
-
-public class ContractProductTransactionFeeModel
-{
-    public Guid TransactionFeeId { get; set; }
-    public string? Description { get; set; }
-    public CalculationType CalculationType { get; set; }
-    public FeeType FeeType { get; set; }
-    public decimal Value { get; set; }
-}
 
 // File Processing Models
 public class FileImportLogModel

--- a/EstateManagementUI.BlazorServer/Program.cs
+++ b/EstateManagementUI.BlazorServer/Program.cs
@@ -243,6 +243,7 @@ else
     
     builder.Services.AddSingleton<IEstateUIService, EstateUIService>();
     builder.Services.AddSingleton<IOperatorUIService, OperatorUIService>();
+    builder.Services.AddSingleton<IContractUIService, ContractUIService>();
 }
 
 builder.Host.UseWindowsService();

--- a/EstateManagementUI.BlazorServer/UIServices/ContractUIService.cs
+++ b/EstateManagementUI.BlazorServer/UIServices/ContractUIService.cs
@@ -1,0 +1,119 @@
+﻿using EstateManagementUI.BlazorServer.Factories;
+using EstateManagementUI.BlazorServer.Models;
+using EstateManagementUI.BusinessLogic.Requests;
+using MediatR;
+using Shared.Results;
+using SimpleResults;
+using static FastExpressionCompiler.ExpressionCompiler;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
+using Result = SimpleResults.Result;
+
+namespace EstateManagementUI.BlazorServer.UIServices;
+
+public interface IContractUIService {
+    Task<Result<List<ContractModels.ContractModel>>> GetContracts(CorrelationId correlationId,
+                                                                  Guid estateId);
+
+    Task<Result<ContractModels.ContractModel>> GetContract(CorrelationId correlationId,
+                                                           Guid estateId,
+                                                           Guid contractId);
+
+    Task<Result> AddProductToContract(CorrelationId correlationId,
+                                      Guid estateId,
+                                      Guid contractId,
+                                      ContractModels.AddProductModel productModel);
+
+    Task<Result> AddTransactionFeeToProduct(CorrelationId correlationId,
+                                            Guid estateId,
+                                            Guid contractId,
+                                            Guid contractProductId,
+                                            ContractModels.AddTransactionFeeModel feeModel);
+
+    Task<Result> RemoveTransactionFeeFromProduct(CorrelationId correlationId,
+                                            Guid estateId,
+                                            Guid contractId,
+                                            Guid contractProductId,
+                                            Guid transactionFeeId);
+
+    Task<Result> CreateContract(CorrelationId correlationId, Guid estateId, ContractModels.CreateContractFormModel createContractFormModel);
+}
+
+public class ContractUIService : IContractUIService {
+    private readonly IMediator Mediator;
+
+    public ContractUIService(IMediator mediator) {
+        this.Mediator = mediator;
+    }
+
+    public async Task<Result<List<ContractModels.ContractModel>>> GetContracts(CorrelationId correlationId,
+                                                                               Guid estateId) {
+        var result = await this.Mediator.Send(new ContractQueries.GetContractsQuery(correlationId, estateId));
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
+        var contracts = ModelFactory.ConvertFrom(result.Data);
+        return Result.Success(contracts);
+    }
+
+    public async Task<Result<ContractModels.ContractModel>> GetContract(CorrelationId correlationId,
+                                                                        Guid estateId,
+                                                                        Guid contractId) {
+        var result = await this.Mediator.Send(new ContractQueries.GetContractQuery(correlationId, estateId, contractId));
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
+        var contract = ModelFactory.ConvertFrom(result.Data);
+        return Result.Success(contract);
+    }
+
+    public async Task<Result> AddProductToContract(CorrelationId correlationId,
+                                                   Guid estateId,
+                                                   Guid contractId,
+                                                   ContractModels.AddProductModel productModel) {
+        ContractCommands.AddProductToContractCommand command = new(CorrelationIdHelper.New(), estateId, contractId, productModel.ProductName!, productModel.DisplayText!, productModel.IsVariableValue ? null : productModel.Value);
+
+        Result result = await this.Mediator.Send(command);
+
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
+        return Result.Success();
+    }
+
+    public async Task<Result> AddTransactionFeeToProduct(CorrelationId correlationId,
+                                                         Guid estateId,
+                                                         Guid contractId,
+                                                         Guid contractProductId,
+                                                         ContractModels.AddTransactionFeeModel feeModel) {
+        var command = new ContractCommands.AddTransactionFeeToProductCommand(CorrelationIdHelper.New(), estateId, contractId, contractProductId, feeModel.Description!, feeModel.FeeValue!.Value, feeModel.CalculationType, feeModel.FeeType);
+
+        Result result = await this.Mediator.Send(command);
+
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
+        return Result.Success();
+    }
+
+    public async Task<Result> RemoveTransactionFeeFromProduct(CorrelationId correlationId,
+                                                              Guid estateId,
+                                                              Guid contractId,
+                                                              Guid contractProductId,
+                                                              Guid transactionFeeId) {
+        var command = new ContractCommands.RemoveTransactionFeeFromProductCommand(CorrelationIdHelper.New(), estateId, contractId, contractProductId, transactionFeeId);
+
+        Result result = await this.Mediator.Send(command);
+
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
+        return Result.Success();
+    }
+
+    public async Task<Result> CreateContract(CorrelationId correlationId,
+                                             Guid estateId,
+                                             ContractModels.CreateContractFormModel createContractFormModel) {
+        var command = new ContractCommands.CreateContractCommand(CorrelationIdHelper.New(), estateId, createContractFormModel.Description!, Guid.Parse(createContractFormModel.OperatorId!));
+
+        Result result = await this.Mediator.Send(command);
+
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
+        return Result.Success();
+    }
+}

--- a/EstateManagementUI.BlazorServer/UIServices/OperatorUIService.cs
+++ b/EstateManagementUI.BlazorServer/UIServices/OperatorUIService.cs
@@ -11,6 +11,7 @@ namespace EstateManagementUI.BlazorServer.UIServices;
 public interface IOperatorUIService
 {
     Task<Result<List<OperatorModels.OperatorModel>>> GetOperators(CorrelationId correlationId, Guid estateId);
+    Task<Result<List<OperatorModels.OperatorDropDownModel>>> GetOperatorsForDropDown(CorrelationId correlationId, Guid estateId);
     Task<Result<OperatorModels.OperatorModel>> GetOperator(CorrelationId correlationId, Guid estateId, Guid operatorId);
 
     Task<Result> UpdateOperator(CorrelationId correlationId, Guid estateId, Guid operatorId, OperatorModels.EditOperatorModel editOperatorModel);
@@ -32,9 +33,18 @@ public class OperatorUIService : IOperatorUIService
         return Result.Success(operators);
     }
 
+    public async Task<Result<List<OperatorModels.OperatorDropDownModel>>> GetOperatorsForDropDown(CorrelationId correlationId,
+                                                                                                  Guid estateId) {
+        var result = await this.Mediator.Send(new OperatorQueries.GetOperatorsForDropDownQuery(correlationId, estateId));
+        if (result.IsFailed)
+            return ResultHelpers.CreateFailure(result);
+        var operators = ModelFactory.ConvertFrom(result.Data);
+        return Result.Success(operators);
+    }
+
     public async Task<Result<OperatorModels.OperatorModel>> GetOperator(CorrelationId correlationId,
-                                                         Guid estateId,
-                                                         Guid operatorId) {
+                                                                        Guid estateId,
+                                                                        Guid operatorId) {
         var result = await this.Mediator.Send(new OperatorQueries.GetOperatorQuery(correlationId, estateId, operatorId));
         if (result.IsFailed)
             return ResultHelpers.CreateFailure(result);


### PR DESCRIPTION
- Replace direct MediatR usage with IContractUIService in contract pages and tests
- Move contract-related models to ContractModels.cs for clarity
- Register ContractUIService in DI container
- Update ModelFactory and OperatorUIService for new model structure
- Improve error handling and update UI for contract operations
- Add unit tests for ContractUIService
- Minor UI changes: "Cancel" → "Back to List" in edit pages
closes #738 