### PR TITLE
Read client credentials from config, not hardcoded

### DIFF
--- a/EstateManagementUI.BlazorServer/appsettings.Test.json
+++ b/EstateManagementUI.BlazorServer/appsettings.Test.json
@@ -11,7 +11,9 @@
     "SecurityServicePort": null,
     "HttpClientIgnoreCertificateErrors": false,
     "TestMode": true,
-    "TestUserRole": "Estate"
+    "TestUserRole": "Estate",
+    //"ClientId": "estateUIClient",
+    //"ClientSecret": "Secret1"
   },
   "Authentication": {
     "Authority": "https://localhost:5001",

--- a/EstateManagementUI.BlazorServer/appsettings.json
+++ b/EstateManagementUI.BlazorServer/appsettings.json
@@ -14,7 +14,9 @@
     "TransactionProcessorApi": "http://127.0.0.1:5002",
     "EstateReportingApi": "http://127.0.0.1:5011",
     "FileProcessorApi": "http://127.0.0.1:5009",
-    "SecurityService": "https://127.0.0.1:5001"
+    "SecurityService": "https://127.0.0.1:5001",
+    "ClientId": "serviceClient",
+    "ClientSecret": "d192cbc46d834d0da90e8a9d50ded543"
   },
   "Authentication": {
     "Authority": "https://localhost:5001",

--- a/EstateManagmentUI.BusinessLogic/Client/DateMethods.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/DateMethods.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using Shared.General;
 using TransactionProcessor.Client;
 
 namespace EstateManagementUI.BusinessLogic.Client
@@ -24,7 +25,8 @@ namespace EstateManagementUI.BusinessLogic.Client
         private readonly ISecurityServiceClient SecurityServiceClient;
         private readonly ITransactionProcessorClient TransactionProcessorClient;
 
-        public ApiClient(IEstateReportingApiClient estateReportingApiClient, ISecurityServiceClient securityServiceClient,
+        public ApiClient(IEstateReportingApiClient estateReportingApiClient, 
+                         ISecurityServiceClient securityServiceClient,
                          ITransactionProcessorClient transactionProcessorClient) {
             this.EstateReportingApiClient = estateReportingApiClient;
             this.SecurityServiceClient = securityServiceClient;
@@ -50,7 +52,9 @@ namespace EstateManagementUI.BusinessLogic.Client
         private async Task<Result<String>> GetToken(CancellationToken cancellationToken) {
             // Get a token here 
             // TODO: Add caching
-            Result<TokenResponse>? token = await this.SecurityServiceClient.GetToken("serviceClient", "d192cbc46d834d0da90e8a9d50ded543", cancellationToken);
+            var clientId = ConfigurationReader.GetValueOrDefault("AppSettings", "ClientId", "");
+            var clientSecret = ConfigurationReader.GetValueOrDefault("AppSettings", "ClientSecret", "");
+            Result<TokenResponse>? token = await this.SecurityServiceClient.GetToken(clientId, clientSecret, cancellationToken);
             if (token.IsFailed)
                 return ResultHelpers.CreateFailure(token);
             return Result.Success<String>(token.Data.AccessToken);

--- a/EstateManagmentUI.BusinessLogic/EstateManagementUI.BusinessLogic.csproj
+++ b/EstateManagmentUI.BusinessLogic/EstateManagementUI.BusinessLogic.csproj
@@ -9,6 +9,7 @@
 		<PackageReference Include="ClientProxyBase" Version="2025.12.2" />
 		<PackageReference Include="MediatR" Version="14.0.0" />
 		<PackageReference Include="SecurityService.Client" Version="2025.12.2" />
+		<PackageReference Include="Shared" Version="2025.12.2" />
 		<PackageReference Include="Shared.Results" Version="2025.12.2" />
 		<PackageReference Include="SimpleResults" Version="4.0.0" />
 		<PackageReference Include="TransactionProcessor.Client" Version="2025.12.1" />


### PR DESCRIPTION
ClientId and ClientSecret are now loaded from appsettings.json and appsettings.Test.json using a configuration reader, improving flexibility and security. ApiClient constructor updated accordingly. Added Shared package dependency. Commented-out credential lines added for reference in test config.

closes #651 