### PR TITLE
Update logout redirect to /entry instead of home page

### DIFF
--- a/EstateManagementUI.BlazorServer/Common/BoostrapperExtensions.cs
+++ b/EstateManagementUI.BlazorServer/Common/BoostrapperExtensions.cs
@@ -40,7 +40,7 @@ public static class BoostrapperExtensions {
         {
             await context.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme);
             await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-            return Results.Redirect("/");
+            return Results.Redirect("/entry");
         }).RequireAuthorization();
         return app;
     }
@@ -55,7 +55,7 @@ public static class BoostrapperExtensions {
         app.MapGet("/logout", (HttpContext context) =>
         {
             // In test mode, just redirect to home
-            return Results.Redirect("/");
+            return Results.Redirect("/entry");
         }).RequireAuthorization();
 
         return app;


### PR DESCRIPTION
Changed the logout endpoint in both main and test login configurations to redirect users to "/entry" after logging out, rather than the root ("/") URL. This ensures a consistent post-logout experience.

closes #704 