### PR TITLE
Add operator transaction summary report to UI and backend

### DIFF
--- a/EstateManagementUI.BlazorServer/Common/BoostrapperExtensions.cs
+++ b/EstateManagementUI.BlazorServer/Common/BoostrapperExtensions.cs
@@ -235,12 +235,12 @@ public static class BoostrapperExtensions {
         return builder;
     }
 
-    public static WebApplicationBuilder RegisterTestMediator(this WebApplicationBuilder builder) {
-        Console.WriteLine("Registering TestMediatorService with in-memory test data store");
-        builder.Services.AddSingleton<ITestDataStore, TestDataStore>();
-        builder.Services.AddSingleton<IMediator, TestMediatorService>();
-        return builder;
-    }
+    //public static WebApplicationBuilder RegisterTestMediator(this WebApplicationBuilder builder) {
+    //    Console.WriteLine("Registering TestMediatorService with in-memory test data store");
+    //    builder.Services.AddSingleton<ITestDataStore, TestDataStore>();
+    //    builder.Services.AddSingleton<IMediator, TestMediatorService>();
+    //    return builder;
+    //}
 
     public static WebApplicationBuilder RegisterProductionMeriator(this WebApplicationBuilder builder) {
         builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(EstateRequestHandler).Assembly));

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor
@@ -267,7 +267,7 @@
                                         </td>
                                         <td class="text-right">@item.Value.ToString("C")</td>
                                         <td class="text-right text-red-600">@item.TotalFees.ToString("C")</td>
-                                        @* <td class="text-right font-medium">@item.NetAmount.ToString("C")</td> *@
+                                        <td class="text-right font-medium">@item.NetAmount.ToString("C")</td>
                                         <td class="text-sm text-gray-600">@(item.SettlementReference ?? "-")</td>
                                     </tr>
                                 }

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor.cs
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionDetail.razor.cs
@@ -90,6 +90,11 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Reporting
                 _selectedMerchantIds = new List<string> { query["merchantId"] };
             }
 
+            if (!string.IsNullOrEmpty(query["operatorId"]))
+            {
+                this._selectedOperatorIds = new List<string> { query["operatorId"] };
+            }
+
             if (!string.IsNullOrEmpty(query["startDate"]))
             {
                 if (DateOnly.TryParse(query["startDate"], out var startDate))
@@ -323,9 +328,8 @@ namespace EstateManagementUI.BlazorServer.Components.Pages.Reporting
         {
             return status switch
             {
-                "Successful" => "badge-success",
-                "Failed" => "badge-danger",
-                "Reversed" => "badge-warning",
+                "Authorised" => "badge-success",
+                "Declined" => "badge-danger",
                 _ => "badge-default"
             };
         }

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryMerchant.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryMerchant.razor
@@ -206,7 +206,7 @@
                                             <span class="@rateClass font-medium">@successRate.ToString("F1")%</span>
                                         </td>
                                         <td class="text-center">
-                                            <button @onclick="() => DrillDownToDetail(item.MerchantId)" 
+                                            <button @onclick="() => DrillDownToDetail(item.MerchantReportingId)" 
                                                     class="btn btn-sm btn-primary"
                                                     title="View detailed transactions">
                                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryOperator.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Reporting/TransactionSummaryOperator.razor
@@ -9,7 +9,7 @@
 @rendermode InteractiveServer
 @inject IMediator Mediator
 @inject NavigationManager Navigation
-@inject ILogger<TransactionSummaryOperator> Logger
+@inherits AuthorizedComponentBase
 
 <PageTitle>Transaction Summary by Operator</PageTitle>
 
@@ -74,13 +74,13 @@
                     <!-- Merchant Filter -->
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-2">Merchant</label>
-                        <select @bind="_selectedMerchantId" class="form-control">
-                            <option value="">All Merchants</option>
+                        <select @bind="_selectedMerchant" class="form-control">
+                            <option value="-1">All Merchants</option>
                             @if (merchants != null)
                             {
                                 @foreach (var merchant in merchants)
                                 {
-                                    <option value="@merchant.MerchantId">@merchant.MerchantName</option>
+                                    <option value="@merchant.MerchantReportingId">@merchant.MerchantName</option>
                                 }
                             }
                         </select>
@@ -89,13 +89,13 @@
                     <!-- Operator Filter -->
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-2">Operator</label>
-                        <select @bind="_selectedOperatorId" class="form-control">
-                            <option value="">All Operators</option>
+                        <select @bind="_selectedOperator" class="form-control">
+                            <option value="-1">All Operators</option>
                             @if (operators != null)
                             {
                                 @foreach (var op in operators)
                                 {
-                                    <option value="@op.OperatorId">@op.OperatorName</option>
+                                    <option value="@op.OperatorReportingId">@op.OperatorName</option>
                                 }
                             }
                         </select>
@@ -125,7 +125,7 @@
                 </div>
                 <div class="info-box-content">
                     <span class="info-box-text">Total Operators</span>
-                    <span class="info-box-number">@totalOperators</span>
+                    <span class="info-box-number">@summaryData.Summary.TotalOperators</span>
                 </div>
             </div>
             
@@ -137,7 +137,7 @@
                 </div>
                 <div class="info-box-content">
                     <span class="info-box-text">Total Transactions</span>
-                    <span class="info-box-number">@totalTransactions.ToString("N0")</span>
+                    <span class="info-box-number">@summaryData.Summary.TotalCount.ToString("N0")</span>
                 </div>
             </div>
             
@@ -149,19 +149,19 @@
                 </div>
                 <div class="info-box-content">
                     <span class="info-box-text">Total Value</span>
-                    <span class="info-box-number">@totalValue.ToString("C")</span>
+                    <span class="info-box-number">@summaryData.Summary.TotalValue.ToString("C")</span>
                 </div>
             </div>
             
             <div class="info-box">
                 <div class="info-box-icon bg-admin-info">
                     <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
                     </svg>
                 </div>
                 <div class="info-box-content">
-                    <span class="info-box-text">Total Fees Earned</span>
-                    <span class="info-box-number">@totalFees.ToString("C")</span>
+                    <span class="info-box-text">Average Transaction</span>
+                    <span class="info-box-number">@summaryData.Summary.AverageValue.ToString("C")</span>
                 </div>
             </div>
         </div>
@@ -172,7 +172,7 @@
                 <h3 class="card-title">Operator Transaction Summary</h3>
             </div>
             <div class="card-body">
-                @if (summaryData != null && summaryData.Any())
+                @if (summaryData != null && summaryData.Operators.Any())
                 {
                     <div class="overflow-x-auto">
                         <table class="table">
@@ -181,35 +181,47 @@
                                     <th>Operator Name</th>
                                     <th class="text-right">Transaction Count</th>
                                     <th class="text-right">Transaction Value</th>
-                                    <th class="text-right">Fees Earned</th>
+                                    @* <th class="text-right">Fees Earned</th> *@
                                     <th class="text-right">Average Value</th>
                                     <th class="text-right">Successful</th>
                                     <th class="text-right">Failed</th>
-                                    <th class="text-right">Failure Rate</th>
+                                    <th class="text-right">Success Rate</th>
+                                    <th class="text-right">Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                @foreach (var item in summaryData)
+                                @foreach (var item in summaryData.Operators)
                                 {
                                     <tr>
                                         <td class="font-medium">@item.OperatorName</td>
-                                        <td class="text-right">@item.TotalTransactionCount.ToString("N0")</td>
-                                        <td class="text-right">@item.TotalTransactionValue.ToString("C")</td>
-                                        <td class="text-right font-medium text-green-600">@item.TotalFeesEarned.ToString("C")</td>
-                                        <td class="text-right">@item.AverageTransactionValue.ToString("C")</td>
-                                        <td class="text-right text-green-600">@item.SuccessfulTransactionCount.ToString("N0")</td>
-                                        <td class="text-right text-red-600">@item.FailedTransactionCount.ToString("N0")</td>
+                                        <td class="text-right">@item.TotalCount.ToString("N0")</td>
+                                        <td class="text-right">@item.TotalValue.ToString("C")</td>
+                                        @* <td class="text-right font-medium text-green-600">@item.TotalFeesEarned.ToString("C")</td> *@
+                                        <td class="text-right">@item.AverageValue.ToString("C")</td>
+                                        <td class="text-right text-green-600">@item.AuthorisedCount.ToString("N0")</td>
+                                        <td class="text-right text-red-600">@item.DeclinedCount.ToString("N0")</td>
                                         <td class="text-right">
                                             @{
-                                                var failureRate = CalculateFailureRate(item.FailedTransactionCount, item.TotalTransactionCount);
-                                                var rateClass = GetFailureRateClass(failureRate);
+                                                var successRate = item.AuthorisedPercentage * 100.0m;
+                                                var rateClass = successRate >= 90 ? "text-green-600" : successRate >= 75 ? "text-yellow-600" : "text-red-600";
                                             }
-                                            <span class="@rateClass font-medium">@failureRate.ToString("F1")%</span>
+                                            <span class="@rateClass font-medium">@successRate.ToString("F1")%</span>
+                                        </td>
+                                        <td class="text-center">
+                                            <button @onclick="() => DrillDownToDetail(item.OperatorReportingId)"
+                                                    class="btn btn-sm btn-primary"
+                                                    title="View detailed transactions">
+                                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
+                                                </svg>
+                                                View Details
+                                            </button>
                                         </td>
                                     </tr>
                                 }
                             </tbody>
-                            <tfoot class="bg-gray-50 font-semibold">
+                           @*  <tfoot class="bg-gray-50 font-semibold">
                                 <tr>
                                     <td>Total</td>
                                     <td class="text-right">@totalTransactions.ToString("N0")</td>
@@ -226,7 +238,7 @@
                                         <span class="@overallRateClass">@overallFailureRate.ToString("F1")%</span>
                                     </td>
                                 </tr>
-                            </tfoot>
+                            </tfoot> *@
                         </table>
                     </div>
                 }
@@ -243,158 +255,3 @@
         </div>
     }
 </div>
-
-@code {
-    private bool isLoading = true;
-    private string? errorMessage;
-    
-    // Filter states
-    private DateOnly _startDate = DateOnly.FromDateTime(DateTime.Now.AddDays(-30));
-    private DateOnly _endDate = DateOnly.FromDateTime(DateTime.Now);
-    private string _selectedMerchantId = "";
-    private string _selectedOperatorId = "";
-    
-    // Data
-    private List<OperatorTransactionSummaryModel>? summaryData;
-    private List<MerchantDropDownModel>? merchants;
-    private List<OperatorDropDownModel>? operators;
-    
-    // KPIs
-    private int totalOperators = 0;
-    private int totalTransactions = 0;
-    private decimal totalValue = 0;
-    private decimal totalFees = 0;
-    private int totalSuccessful = 0;
-    private int totalFailed = 0;
-    
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadData();
-    }
-    
-    private async Task LoadData()
-    {
-        try
-        {
-            isLoading = true;
-            errorMessage = null;
-            StateHasChanged();
-            
-            var correlationId = new CorrelationId(Guid.NewGuid());
-            var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-            var accessToken = "stubbed-token";
-            
-            // Load filter options
-            var merchantsTask = Mediator.Send(new MerchantQueries.GetMerchantsForDropDownQuery(correlationId, estateId));
-            var operatorsTask = Mediator.Send(new OperatorQueries.GetOperatorsForDropDownQuery(correlationId, estateId));
-            
-            await Task.WhenAll(merchantsTask, operatorsTask);
-            
-            if (merchantsTask.Result.IsSuccess)
-                merchants = ModelFactory.ConvertFrom(merchantsTask.Result.Data);
-            
-            if (operatorsTask.Result.IsSuccess)
-                operators = ModelFactory.ConvertFrom(operatorsTask.Result.Data);
-            
-            // Load summary data
-            await LoadSummaryData();
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"Failed to load data: {ex.Message}";
-            Logger.LogError(ex, "Error loading operator transaction summary data");
-        }
-        finally
-        {
-            isLoading = false;
-            StateHasChanged();
-        }
-    }
-    
-    private async Task LoadSummaryData()
-    {
-        try
-        {
-            var correlationId = new CorrelationId(Guid.NewGuid());
-            var estateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-            var accessToken = "stubbed-token";
-            
-            var startDate = _startDate.ToDateTime(TimeOnly.MinValue);
-            var endDate = _endDate.ToDateTime(TimeOnly.MaxValue);
-            
-            Guid? merchantId = string.IsNullOrEmpty(_selectedMerchantId) ? null : Guid.Parse(_selectedMerchantId);
-            Guid? operatorId = string.IsNullOrEmpty(_selectedOperatorId) ? null : Guid.Parse(_selectedOperatorId);
-            
-            var result = await Mediator.Send(new Queries.GetOperatorTransactionSummaryQuery(
-                correlationId, 
-                accessToken, 
-                estateId, 
-                startDate, 
-                endDate, 
-                merchantId, 
-                operatorId
-            ));
-            
-            if (result.IsSuccess && result.Data != null)
-            {
-                summaryData = ModelFactory.ConvertFrom(result.Data);
-                CalculateKPIs();
-            }
-            else
-            {
-                errorMessage = result.Message ?? "Failed to load summary data";
-            }
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"Failed to load summary data: {ex.Message}";
-            Logger.LogError(ex, "Error loading summary data");
-        }
-    }
-    
-    private void CalculateKPIs()
-    {
-        if (summaryData == null || !summaryData.Any())
-        {
-            totalOperators = 0;
-            totalTransactions = 0;
-            totalValue = 0;
-            totalFees = 0;
-            totalSuccessful = 0;
-            totalFailed = 0;
-            return;
-        }
-        
-        totalOperators = summaryData.Count;
-        totalTransactions = summaryData.Sum(s => s.TotalTransactionCount);
-        totalValue = summaryData.Sum(s => s.TotalTransactionValue);
-        totalFees = summaryData.Sum(s => s.TotalFeesEarned);
-        totalSuccessful = summaryData.Sum(s => s.SuccessfulTransactionCount);
-        totalFailed = summaryData.Sum(s => s.FailedTransactionCount);
-    }
-    
-    private double CalculateFailureRate(int failed, int total)
-    {
-        return total > 0 ? (failed * 100.0 / total) : 0;
-    }
-    
-    private string GetFailureRateClass(double failureRate)
-    {
-        return failureRate <= 5 ? "text-green-600" : failureRate <= 10 ? "text-yellow-600" : "text-red-600";
-    }
-    
-    private async Task ApplyFilters()
-    {
-        await LoadSummaryData();
-    }
-    
-    private async Task ClearFilters()
-    {
-        _startDate = DateOnly.FromDateTime(DateTime.Now.AddDays(-30));
-        _endDate = DateOnly.FromDateTime(DateTime.Now);
-        _selectedMerchantId = "";
-        _selectedOperatorId = "";
-        await LoadSummaryData();
-    }
-}
-

--- a/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
+++ b/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
@@ -529,7 +529,8 @@ namespace EstateManagementUI.BlazorServer.Factories {
                     Merchant = resultDataTransaction.Merchant,
                     DateTime = resultDataTransaction.DateTime,
                     Id = resultDataTransaction.Id,
-                    SettlementReference = resultDataTransaction.SettlementReference
+                    SettlementReference = resultDataTransaction.SettlementReference,
+                    NetAmount = resultDataTransaction.Value - resultDataTransaction.TotalFees
                 });
             }
             return model;
@@ -549,11 +550,41 @@ namespace EstateManagementUI.BlazorServer.Factories {
                     AverageValue = resultDataMerchant.AverageValue,
                     DeclinedCount = resultDataMerchant.DeclinedCount,
                     MerchantId = resultDataMerchant.MerchantId,
+                    MerchantReportingId = resultDataMerchant.MerchantReportingId,
                     MerchantName = resultDataMerchant.MerchantName,
                     AuthorisedPercentage = resultDataMerchant.AuthorisedPercentage,
                     AuthorisedCount = resultDataMerchant.AuthorisedCount,
                     TotalCount = resultDataMerchant.TotalCount,
                     TotalValue= resultDataMerchant.TotalValue
+                });
+            }
+
+            return model;
+        }
+
+        public static TransactionModels.TransactionSummaryByOperatorResponse ConvertFrom(BusinessLogic.Models.TransactionModels.TransactionSummaryByOperatorResponse resultData) {
+            TransactionModels.TransactionSummaryByOperatorResponse model = new();
+            model.Summary = new TransactionModels.OperatorDetailSummary
+            {
+                AverageValue = resultData.Summary.AverageValue,
+                TotalCount = resultData.Summary.TotalCount,
+                TotalOperators = resultData.Summary.TotalOperators,
+                TotalValue = resultData.Summary.TotalValue
+            };
+            model.Operators = new();
+            foreach (BusinessLogic.Models.TransactionModels.OperatorDetail resultDataOperator in resultData.Operators)
+            {
+                model.Operators.Add(new TransactionModels.OperatorDetail()
+                {
+                    AverageValue = resultDataOperator.AverageValue,
+                    DeclinedCount = resultDataOperator.DeclinedCount,
+                    OperatorId = resultDataOperator.OperatorId,
+                    OperatorReportingId = resultDataOperator.OperatorReportingId,
+                    OperatorName = resultDataOperator.OperatorName,
+                    AuthorisedPercentage = resultDataOperator.AuthorisedPercentage,
+                    AuthorisedCount = resultDataOperator.AuthorisedCount,
+                    TotalCount = resultDataOperator.TotalCount,
+                    TotalValue = resultDataOperator.TotalValue
                 });
             }
 

--- a/EstateManagementUI.BlazorServer/Models/TransactionModels.cs
+++ b/EstateManagementUI.BlazorServer/Models/TransactionModels.cs
@@ -27,6 +27,7 @@ public record TransactionModels
         public String Status { get; set; }
         public Decimal Value { get; set; }
         public Decimal TotalFees { get; set; }
+        public Decimal NetAmount { get; set; }
         public String SettlementReference { get; set; }
     }
 
@@ -52,6 +53,33 @@ public record TransactionModels
     public class MerchantDetailSummary
     {
         public Int32 TotalMerchants { get; set; }
+        public Int32 TotalCount { get; set; }
+        public Decimal TotalValue { get; set; }
+        public Decimal AverageValue { get; set; }
+    }
+
+    public class TransactionSummaryByOperatorResponse
+    {
+        public List<OperatorDetail> Operators { get; set; }
+        public OperatorDetailSummary Summary { get; set; }
+    }
+
+    public class OperatorDetail
+    {
+        public Guid OperatorId { get; set; }
+        public Int32 OperatorReportingId { get; set; }
+        public string OperatorName { get; set; }
+        public Int32 TotalCount { get; set; }
+        public Decimal TotalValue { get; set; }
+        public Decimal AverageValue { get; set; }
+        public Int32 AuthorisedCount { get; set; }
+        public Int32 DeclinedCount { get; set; }
+        public Decimal AuthorisedPercentage { get; set; }
+    }
+
+    public class OperatorDetailSummary
+    {
+        public Int32 TotalOperators { get; set; }
         public Int32 TotalCount { get; set; }
         public Decimal TotalValue { get; set; }
         public Decimal AverageValue { get; set; }

--- a/EstateManagementUI.BlazorServer/Permissions/PermissionFunction.cs
+++ b/EstateManagementUI.BlazorServer/Permissions/PermissionFunction.cs
@@ -17,5 +17,6 @@ public enum PermissionFunction
 
     // Reporting
     TransactionDetailReport,
-    TransactionMerchantSummaryReport
+    TransactionMerchantSummaryReport,
+    TransactionOperatorSummaryReport
 }

--- a/EstateManagementUI.BlazorServer/Program.cs
+++ b/EstateManagementUI.BlazorServer/Program.cs
@@ -41,11 +41,12 @@ builder.Services.AddHttpContextAccessor();
 // Register Permission services
 builder = builder.RegisterPermissionServices();
 
-builder = testMode switch {
-    TestMode.BackedByTestDataStore => builder.RegisterTestMediator(),
-    TestMode.Full => builder.RegisterTestMediator(),
-    _ => builder.RegisterProductionMeriator().RegisterClients().RegisterUIServices()
-};
+//builder = testMode switch {
+//    TestMode.BackedByTestDataStore => builder.RegisterTestMediator(),
+//    TestMode.Full => builder.RegisterTestMediator(),
+//    _ => builder.RegisterProductionMeriator().RegisterClients().RegisterUIServices()
+//};
+builder.RegisterProductionMeriator().RegisterClients().RegisterUIServices();
 
 builder.Host.UseWindowsService();
 

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/TransactionSummaryByMerchantRequest.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/TransactionSummaryByMerchantRequest.cs
@@ -13,3 +13,15 @@ public class TransactionSummaryByMerchantRequest
     [JsonProperty("end_date")]
     public DateTime EndDate { get; set; }
 }
+
+public class TransactionSummaryByOperatorRequest
+{
+    [JsonProperty("operators")]
+    public List<Int32>? Operators { get; set; }
+    [JsonProperty("merchants")]
+    public List<Int32>? Merchants { get; set; }
+    [JsonProperty("start_date")]
+    public DateTime StartDate { get; set; }
+    [JsonProperty("end_date")]
+    public DateTime EndDate { get; set; }
+}

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/TransactionSummaryByMerchantResponse.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/TransactionSummaryByMerchantResponse.cs
@@ -9,3 +9,45 @@ public class TransactionSummaryByMerchantResponse
     [JsonProperty("summary")]
     public MerchantDetailSummary Summary { get; set; }
 }
+
+public class TransactionSummaryByOperatorResponse
+{
+    [JsonProperty("operators")]
+    public List<OperatorDetail> Operators { get; set; }
+    [JsonProperty("summary")]
+    public OperatorDetailSummary Summary { get; set; }
+}
+
+public class OperatorDetail
+{
+    [JsonProperty("operator_id")]
+    public Guid OperatorId { get; set; }
+    [JsonProperty("operator_reporting_id")]
+    public Int32 OperatorReportingId { get; set; }
+    [JsonProperty("operator_name")]
+    public string OperatorName { get; set; }
+    [JsonProperty("total_count")]
+    public Int32 TotalCount { get; set; }
+    [JsonProperty("total_value")]
+    public Decimal TotalValue { get; set; }
+    [JsonProperty("average_value")]
+    public Decimal AverageValue { get; set; }
+    [JsonProperty("authorised_count")]
+    public Int32 AuthorisedCount { get; set; }
+    [JsonProperty("declined_count")]
+    public Int32 DeclinedCount { get; set; }
+    [JsonProperty("authorised_percentage")]
+    public Decimal AuthorisedPercentage { get; set; }
+}
+
+public class OperatorDetailSummary
+{
+    [JsonProperty("total_operators")]
+    public Int32 TotalOperators { get; set; }
+    [JsonProperty("total_count")]
+    public Int32 TotalCount { get; set; }
+    [JsonProperty("total_value")]
+    public Decimal TotalValue { get; set; }
+    [JsonProperty("average_value")]
+    public Decimal AverageValue { get; set; }
+}

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/EstateReportingApiClient.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/EstateReportingApiClient.cs
@@ -87,6 +87,7 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
                                                CancellationToken cancellationToken);
 
         Task<Result<TransactionSummaryByMerchantResponse>> GetMerchantTransactionSummary(String accessToken, Guid estateId, TransactionSummaryByMerchantRequest request, CancellationToken cancellationToken);
+        Task<Result<TransactionSummaryByOperatorResponse>> GetOperatorTransactionSummary(String accessToken, Guid estateId, TransactionSummaryByOperatorRequest request, CancellationToken cancellationToken);
     }
 
     public class EstateReportingApiClient : ClientProxyBase.ClientProxyBase, IEstateReportingApiClient {
@@ -483,6 +484,33 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
             {
                 // An exception has occurred, add some additional information to the message
                 Exception exception = new Exception($"Error getting merchant transaction summary report for estate {estateId}.", ex);
+
+                return Result.Failure(exception.Message);
+            }
+        }
+
+        public async Task<Result<TransactionSummaryByOperatorResponse>> GetOperatorTransactionSummary(String accessToken,
+                                                                                                      Guid estateId,
+                                                                                                      TransactionSummaryByOperatorRequest request,
+                                                                                                      CancellationToken cancellationToken) {
+            String requestUri = this.BuildRequestUrl($"/api/transactions/transactionsummarybyoperatorreport");
+
+            try
+            {
+                List<(String headerName, String headerValue)> additionalHeaders = [
+                    (EstateIdHeaderName, estateId.ToString())
+                ];
+                Result<TransactionSummaryByOperatorResponse>? result = await this.SendHttpPostRequest<TransactionSummaryByOperatorRequest, TransactionSummaryByOperatorResponse>(requestUri, request, accessToken, additionalHeaders, cancellationToken);
+
+                if (result.IsFailed)
+                    return ResultHelpers.CreateFailure(result);
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                // An exception has occurred, add some additional information to the message
+                Exception exception = new Exception($"Error getting operator transaction summary report for estate {estateId}.", ex);
 
                 return Result.Failure(exception.Message);
             }

--- a/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
@@ -151,6 +151,30 @@ public static class APIModelFactory {
         }
         return model;
     }
+
+    public static TransactionModels.TransactionSummaryByOperatorResponse ConvertFrom(TransactionSummaryByOperatorResponse apiResultData) {
+        TransactionModels.TransactionSummaryByOperatorResponse model = new();
+
+        model.Summary = new TransactionModels.OperatorDetailSummary() { TotalValue = apiResultData.Summary.TotalValue, AverageValue = apiResultData.Summary.AverageValue, TotalCount = apiResultData.Summary.TotalCount, TotalOperators = apiResultData.Summary.TotalOperators };
+        model.Operators = new();
+
+        foreach (OperatorDetail @operator in apiResultData.Operators)
+        {
+            model.Operators.Add(new TransactionModels.OperatorDetail
+            {
+                TotalValue = @operator.TotalValue,
+                OperatorReportingId= @operator.OperatorReportingId,
+                AverageValue = @operator.AverageValue,
+                TotalCount = @operator.TotalCount,
+                AuthorisedCount = @operator.AuthorisedCount,
+                AuthorisedPercentage = @operator.AuthorisedPercentage,
+                DeclinedCount = @operator.DeclinedCount,
+                OperatorId = @operator.OperatorId,
+                OperatorName = @operator.OperatorName
+            });
+        }
+        return model;
+    }
 }
 
 public  static class FactoryExtensions{

--- a/EstateManagmentUI.BusinessLogic/Models/TransactionModels.cs
+++ b/EstateManagmentUI.BusinessLogic/Models/TransactionModels.cs
@@ -67,5 +67,32 @@ namespace EstateManagementUI.BusinessLogic.Models
             public Decimal TotalValue { get; set; }
             public Decimal AverageValue { get; set; }
         }
+
+        public class TransactionSummaryByOperatorResponse
+        {
+            public List<OperatorDetail> Operators { get; set; }
+            public OperatorDetailSummary Summary { get; set; }
+        }
+
+        public class OperatorDetail
+        {
+            public Guid OperatorId { get; set; }
+            public Int32 OperatorReportingId { get; set; }
+            public string OperatorName { get; set; }
+            public Int32 TotalCount { get; set; }
+            public Decimal TotalValue { get; set; }
+            public Decimal AverageValue { get; set; }
+            public Int32 AuthorisedCount { get; set; }
+            public Int32 DeclinedCount { get; set; }
+            public Decimal AuthorisedPercentage { get; set; }
+        }
+
+        public class OperatorDetailSummary
+        {
+            public Int32 TotalOperators { get; set; }
+            public Int32 TotalCount { get; set; }
+            public Decimal TotalValue { get; set; }
+            public Decimal AverageValue { get; set; }
+        }
     }
 }

--- a/EstateManagmentUI.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
+++ b/EstateManagmentUI.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
@@ -9,7 +9,8 @@ namespace EstateManagementUI.BusinessLogic.RequestHandlers;
 public class TransactionRequestHandler : IRequestHandler<TransactionQueries.GetTodaysSalesQuery, Result<TodaysSalesModel>>, 
     IRequestHandler<TransactionQueries.GetTransactionDetailQuery, Result<TransactionModels.TransactionDetailReportResponse>>,
     IRequestHandler<TransactionQueries.GetTodaysFailedSalesQuery, Result<TodaysSalesModel>>,
-    IRequestHandler<TransactionQueries.GetMerchantTransactionSummaryQuery, Result<TransactionModels.TransactionSummaryByMerchantResponse>>
+    IRequestHandler<TransactionQueries.GetMerchantTransactionSummaryQuery, Result<TransactionModels.TransactionSummaryByMerchantResponse>>,
+    IRequestHandler<TransactionQueries.GetOperatorTransactionSummaryQuery, Result<TransactionModels.TransactionSummaryByOperatorResponse>>
 {
     private readonly IApiClient ApiClient;
     public TransactionRequestHandler(IApiClient apiClient) {
@@ -34,5 +35,10 @@ public class TransactionRequestHandler : IRequestHandler<TransactionQueries.GetT
     public async Task<Result<TransactionModels.TransactionSummaryByMerchantResponse>> Handle(TransactionQueries.GetMerchantTransactionSummaryQuery request,
                                                                                         CancellationToken cancellationToken) {
         return await this.ApiClient.GetMerchantTransactionSummary(request, cancellationToken);
+    }
+
+    public async Task<Result<TransactionModels.TransactionSummaryByOperatorResponse>> Handle(TransactionQueries.GetOperatorTransactionSummaryQuery request,
+                                                                                             CancellationToken cancellationToken) {
+        return await this.ApiClient.GetOperatorTransactionSummary(request, cancellationToken);
     }
 }

--- a/EstateManagmentUI.BusinessLogic/Requests/Queries.cs
+++ b/EstateManagmentUI.BusinessLogic/Requests/Queries.cs
@@ -9,6 +9,7 @@ public static class TransactionQueries {
     public record GetTodaysFailedSalesQuery(CorrelationId CorrelationId, Guid EstateId, string ResponseCode, DateTime ComparisonDate) : IRequest<Result<TodaysSalesModel>>;
     public record GetTransactionDetailQuery(CorrelationId CorrelationId, Guid EstateId, DateTime StartDate, DateTime EndDate, List<Int32>? MerchantIds = null, List<Int32>? OperatorIds = null, List<Int32>? ProductIds = null) : IRequest<Result<TransactionModels.TransactionDetailReportResponse>>;
     public record GetMerchantTransactionSummaryQuery(CorrelationId CorrelationId, Guid EstateId, DateTime StartDate, DateTime EndDate, Int32? MerchantId = null, Int32? OperatorId = null) : IRequest<Result<TransactionModels.TransactionSummaryByMerchantResponse>>;
+    public record GetOperatorTransactionSummaryQuery(CorrelationId CorrelationId,Guid EstateId, DateTime StartDate, DateTime EndDate, Int32? MerchantId = null, Int32? OperatorId = null) : IRequest<Result<TransactionModels.TransactionSummaryByOperatorResponse>>;
 }
 
 public static class Queries
@@ -35,7 +36,6 @@ public static class Queries
     
     public record GetMerchantTransactionSummaryQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, DateTime StartDate, DateTime EndDate, Guid? MerchantId = null, Guid? OperatorId = null, Guid? ProductId = null) : IRequest<Result<List<TransactionModels.TransactionSummaryByMerchantResponse>>>;
     public record GetProductPerformanceQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, DateTime StartDate, DateTime EndDate) : IRequest<Result<List<ProductPerformanceModel>>>;
-    public record GetOperatorTransactionSummaryQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, DateTime StartDate, DateTime EndDate, Guid? MerchantId = null, Guid? OperatorId = null) : IRequest<Result<List<OperatorTransactionSummaryModel>>>;
     public record GetMerchantSettlementHistoryQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, Guid? MerchantId, DateTime StartDate, DateTime EndDate) : IRequest<Result<List<MerchantSettlementHistoryModel>>>;
     public record GetSettlementSummaryQuery(CorrelationId CorrelationId, string AccessToken, Guid EstateId, DateTime StartDate, DateTime EndDate, Guid? MerchantId = null, string? Status = null) : IRequest<Result<List<SettlementSummaryModel>>>;
 }

--- a/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
+++ b/EstateManagmentUI.BusinessLogic/Services/TestMediatorService.cs
@@ -10,7 +10,7 @@ namespace EstateManagementUI.BusinessLogic.Services;
 /// Test-enabled MediatR service that uses an in-memory data store
 /// Allows CRUD operations on test data during test execution while maintaining the mediator pattern
 /// </summary>
-public class TestMediatorService : IMediator
+/*public class TestMediatorService : IMediator
 {
     private readonly ITestDataStore _testDataStore;
 
@@ -926,3 +926,4 @@ public class TestMediatorService : IMediator
         return filteredTransactions.OrderByDescending(t => t.TransactionDateTime).ToList();
     }
 }
+*/


### PR DESCRIPTION
- Implemented "Transaction Summary by Operator" report in Blazor UI
- Added new DTOs and models for operator summary in API and UI layers
- Extended API client and backend interface to support operator summary retrieval
- Updated MediatR handlers for new operator summary query
- Refactored UI components for filtering, drill-down, and new metrics
- Added model factory conversions for operator summary data
- Introduced new permission for operator summary report
- Fixed transaction detail status badge and net amount display
- Improved filter logic, error handling, and loading states
- Defaulted to production mediator; commented out test mediator code
closes #644 