### PR TITLE
Add OperatorCount to EstateModel and update tests

### DIFF
--- a/EstateManagementUI.BlazorServer.Tests/UIServices/EstateUIServiceTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/UIServices/EstateUIServiceTests.cs
@@ -91,6 +91,7 @@ namespace EstateManagementUI.BlazorServer.Tests.UIServices
             model.AssignedOperators.ShouldNotBeEmpty();
             model.RecentMerchants.ShouldNotBeEmpty();
             model.RecentContracts.ShouldNotBeEmpty();
+            model.OperatorCount.ShouldBe(1);
         }
 
         [Fact]

--- a/EstateManagementUI.BlazorServer/UIServices/EstateUIService.cs
+++ b/EstateManagementUI.BlazorServer/UIServices/EstateUIService.cs
@@ -66,6 +66,7 @@ public class EstateUIService : IEstateUIService
             RecentContracts = contracts,
             RecentMerchants = merchants,
             UserCount = estateModel.Users.Count,
+            OperatorCount = estateModel.Operators.Count
         };
 
         return Result.Success(resultModel);


### PR DESCRIPTION
Added OperatorCount property to EstateModel in EstateUIService, reflecting the number of operators. Updated EstateUIServiceTests.cs to verify OperatorCount is set correctly.

closes #800 