### PR TITLE
Remove Available Balance from merchant UI and models

### DIFF
--- a/EstateManagementUI.BlazorServer.Tests/Pages/Merchants/MerchantsIndexPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/Merchants/MerchantsIndexPageTests.cs
@@ -134,7 +134,6 @@ public class MerchantsIndexPageTests : BaseTest
         // Assert
         cut.Markup.ShouldContain("Total Merchants");
         cut.Markup.ShouldContain("Total Balance");
-        cut.Markup.ShouldContain("Available Balance");
     }
 
     [Fact]

--- a/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Index.razor
+++ b/EstateManagementUI.BlazorServer/Components/Pages/Merchants/Index.razor
@@ -90,7 +90,6 @@
                         <th>Region</th>
                         <th>Postcode</th>
                         <th>Balance</th>
-                        <th>Available Balance</th>
                         <th>Settlement Schedule</th>
                         <th class="text-right">Actions</th>
                     </tr>
@@ -113,7 +112,6 @@
                             <td class="text-sm">@(merchant.Region ?? "N/A")</td>
                             <td class="font-mono text-sm">@(merchant.PostalCode ?? "N/A")</td>
                             <td class="font-semibold text-green-600">@(merchant.Balance?.ToString("C") ?? "N/A")</td>
-                            <td class="font-semibold">@(merchant.AvailableBalance?.ToString("C") ?? "N/A")</td>
                             <td>
                                 <span class="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium">
                                     @(merchant.SettlementSchedule ?? "Not Set")
@@ -215,10 +213,10 @@
                 <p class="text-sm text-gray-600 mb-1">Total Balance</p>
                 <p class="text-3xl font-bold text-green-600">@pagedMerchants.Sum(m => m.Balance ?? 0).ToString("C")</p>
             </div>
-            <div class="bg-white rounded-lg shadow-md p-6">
+@*             <div class="bg-white rounded-lg shadow-md p-6">
                 <p class="text-sm text-gray-600 mb-1">Available Balance</p>
                 <p class="text-3xl font-bold text-blue-600">@pagedMerchants.Sum(m => m.AvailableBalance ?? 0).ToString("C")</p>
-            </div>
+            </div> *@
         </div>
     }
     else

--- a/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
+++ b/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
@@ -354,7 +354,6 @@ public static class ModelFactory {
         foreach (BusinessLogic.Models.MerchantModels.MerchantListModel merchantListModel in resultData) {
             merchantList.Add(new MerchantListModel {
                 CreatedDateTime = merchantListModel.CreatedDateTime,
-                AvailableBalance = merchantListModel.AvailableBalance,
                 Balance = merchantListModel.Balance,
                 MerchantId = merchantListModel.MerchantId,
                 MerchantName = merchantListModel.MerchantName,

--- a/EstateManagementUI.BlazorServer/Models/MerchantModels.cs
+++ b/EstateManagementUI.BlazorServer/Models/MerchantModels.cs
@@ -86,7 +86,6 @@ public class MerchantModels
         public string? MerchantName { get; set; }
         public string? MerchantReference { get; set; }
         public decimal? Balance { get; set; }
-        public decimal? AvailableBalance { get; set; }
         public string? SettlementSchedule { get; set; }
         public string? Region { get; set; }
         public string? PostalCode { get; set; }

--- a/EstateManagementUI.BlazorServer/appsettings.Development.json
+++ b/EstateManagementUI.BlazorServer/appsettings.Development.json
@@ -12,7 +12,7 @@
     "HttpClientIgnoreCertificateErrors": true,
     "TestMode": "Disabled",
     "TransactionProcessorApi": "http://192.168.1.163:5002",
-    //"EstateReportingApi": "http://192.168.1.163:5011",
+    "EstateReportingApi": "http://192.168.1.163:5011",
     "FileProcessorApi": "http://192.168.1.163:5009",
     "SecurityService": "https://192.168.1.163:5001",
     "ClientId": "serviceClient",


### PR DESCRIPTION
- Removed "Available Balance" column from merchant table and dashboard in Index.razor.
- Deleted AvailableBalance property from MerchantModels and its mapping in ModelFactory.
- Uncommented and activated EstateReportingApi setting in appsettings.Development.json.
closes #801 