### PR TITLE
Update reporting ID properties and mappings for contracts

### DIFF
--- a/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
+++ b/EstateManagementUI.BlazorServer/Factories/ModelFactory.cs
@@ -128,6 +128,7 @@ public static class ModelFactory {
     public static ContractProductModel ConvertFrom(BusinessLogic.Models.ContractModels.ContractProductModel model) {
         var result = new ContractProductModel() {
             ContractProductId = model.ContractProductId,
+            ContractProductReportingId = model.ContractProductReportingId,
             ProductName = model.ProductName,
             DisplayText = model.DisplayText,
             Value = model.Value,

--- a/EstateManagementUI.BlazorServer/UIServices/ContractUIService.cs
+++ b/EstateManagementUI.BlazorServer/UIServices/ContractUIService.cs
@@ -50,7 +50,7 @@ public class ContractUIService : IContractUIService {
 
     public async Task<Result<List<ContractModels.ContractModel>>> GetContracts(CorrelationId correlationId,
                                                                                Guid estateId) {
-        var result = await this.Mediator.Send(new ContractQueries.GetContractsQuery(correlationId, estateId));
+        Result<List<BusinessLogic.Models.ContractModels.ContractModel>> result = await this.Mediator.Send(new ContractQueries.GetContractsQuery(correlationId, estateId));
         if (result.IsFailed)
             return ResultHelpers.CreateFailure(result);
         var contracts = ModelFactory.ConvertFrom(result.Data);

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/ContractProduct.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/ContractProduct.cs
@@ -8,8 +8,8 @@ public class ContractProduct
     public Guid ContractId { get; set; }
     [JsonProperty("product_id")]
     public Guid ProductId { get; set; }
-    [JsonProperty("product_reporting_id")]
-    public Int32 ProductReportingId { get; set; }
+    [JsonProperty("contract_product_reporting_id")]
+    public Int32 ContractProductReportingId { get; set; }
     [JsonProperty("product_name")]
     public String ProductName { get; set; }
     [JsonProperty("display_text")]

--- a/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/ContractProductTransactionFee.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/DataTransferObjects/ContractProductTransactionFee.cs
@@ -14,4 +14,6 @@ public class ContractProductTransactionFee
     public Int32 FeeType { get; set; }
     [JsonProperty("value")] 
     public Decimal Value { get; set; }
+    [JsonProperty("contract_product_transaction_fee_reporting_id")]
+    public Int32 ContractProductTransactionFeeReportingId { get; set; }
 }

--- a/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
+++ b/EstateManagmentUI.BusinessLogic/Client/APIModelFactory.cs
@@ -500,7 +500,7 @@ public  static class FactoryExtensions{
                 DisplayText = contractProduct.DisplayText,
                 ProductName = contractProduct.ProductName,
                 ContractProductId = contractProduct.ProductId,
-                ContractProductReportingId = contractProduct.ProductReportingId,
+                ContractProductReportingId = contractProduct.ContractProductReportingId,
                 NumberOfFees = contractProduct.TransactionFees.Count,
                 TransactionFees = new List<ContractModels.ContractProductTransactionFeeModel>()
             };


### PR DESCRIPTION
Renamed ProductReportingId to ContractProductReportingId in ContractProduct and updated its JSON property. Added ContractProductTransactionFeeReportingId to ContractProductTransactionFee. Updated mapping logic in ModelFactory and APIModelFactory to use the new property names. Made result type explicit in ContractUIService.GetContracts for clarity. These changes ensure consistent naming and mapping of reporting ID fields across models and services.

closes #803 