### PR TITLE
Configure Sentry options via app settings

### DIFF
--- a/EstateManagementUI.BlazorServer/Program.cs
+++ b/EstateManagementUI.BlazorServer/Program.cs
@@ -23,7 +23,8 @@ if (sentrySection != "N/A")
             o.Dsn = sentrySection;
             o.SendDefaultPii = true;
             o.MaxRequestBodySize = RequestSize.Always;
-            o.CaptureBlockingCalls = true;
+            o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+            o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
             o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
         });
     }


### PR DESCRIPTION
CaptureBlockingCalls and IncludeActivityData are now set based on configuration values instead of being hardcoded. This enables easier customization of Sentry behavior through application settings.

closes #823 