### PR TITLE
Format dates as "yyyy-MM-dd" in query string parameters

### DIFF
--- a/EstateManagmentUI.BusinessLogic/BackendAPI/EstateReportingApiClient.cs
+++ b/EstateManagmentUI.BusinessLogic/BackendAPI/EstateReportingApiClient.cs
@@ -712,8 +712,8 @@ namespace EstateManagementUI.BusinessLogic.BackendAPI
 
             QueryStringBuilder builder = new();
             builder.AddParameter("merchantId", merchantId);
-            builder.AddParameter("startDate", startDate);
-            builder.AddParameter("endDate", endDate);
+            builder.AddParameter("startDate", startDate.ToString("yyyy-MM-dd"));
+            builder.AddParameter("endDate", endDate.ToString("yyyy-MM-dd"));
 
             String requestUri = this.BuildRequestUrl($"/api/fileimportlogs?{builder.BuildQueryString()}");
 


### PR DESCRIPTION
Updated startDate and endDate to use "yyyy-MM-dd" string format when building the query string for API requests. This ensures consistent and expected date formatting for the backend API.

closes #776 