### PR TITLE
Centralize NuGet package version management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,39 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />    
+    <PackageVersion Include="bunit.web" Version="1.40.0" />
+    <PackageVersion Include="ClientProxyBase" Version="2026.5.6" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageVersion Include="FileProcessor.Client" Version="2026.5.1" />
+    <PackageVersion Include="IdentityModel" Version="6.2.0" />
+    <PackageVersion Include="Lamar" Version="16.0.0" />
+    <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
+    <PackageVersion Include="MediatR" Version="14.1.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="Reqnroll" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.NUnit" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
+    <PackageVersion Include="SecurityService.Client" Version="2026.5.1" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.6.0" />
+    <PackageVersion Include="Shared" Version="2026.5.6" />
+    <PackageVersion Include="Shared.Results" Version="2026.5.6" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="SimpleResults" Version="4.0.0" />
+    <PackageVersion Include="TransactionProcessor.Client" Version="2026.5.1" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/EstateManagementUI.BlazorServer.Tests/EstateManagementUI.BlazorServer.Tests.csproj
+++ b/EstateManagementUI.BlazorServer.Tests/EstateManagementUI.BlazorServer.Tests.csproj
@@ -11,22 +11,21 @@
   </PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.32.7" />
-    <PackageReference Include="bunit.web" Version="1.32.7" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="bunit.web" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/EstateManagementUI.BlazorServer.Tests/Pages/BaseTest.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/BaseTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using TestContext = Bunit.TestContext;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages;
 

--- a/EstateManagementUI.BlazorServer.Tests/Pages/EntryScreenPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/EntryScreenPageTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using EstateManagementUI.BlazorServer.Components.Pages;
 using Shouldly;
+using TestContext = Bunit.TestContext;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages;
 

--- a/EstateManagementUI.BlazorServer.Tests/Pages/EstateInfoPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/EstateInfoPageTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using EstateManagementUI.BlazorServer.Components.Pages;
 using Shouldly;
+using TestContext = Bunit.TestContext;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages;
 

--- a/EstateManagementUI.BlazorServer.Tests/Pages/FileInfoPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/FileInfoPageTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using Shouldly;
 using FileInfoPage = EstateManagementUI.BlazorServer.Components.Pages.FileInfo;
+using TestContext = Bunit.TestContext;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages;
 

--- a/EstateManagementUI.BlazorServer.Tests/Pages/MerchantInfoPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/MerchantInfoPageTests.cs
@@ -1,5 +1,6 @@
 using Bunit;
 using EstateManagementUI.BlazorServer.Components.Pages;
+using TestContext = Bunit.TestContext;
 using Shouldly;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages;

--- a/EstateManagementUI.BlazorServer.Tests/Pages/NotFoundPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/NotFoundPageTests.cs
@@ -4,6 +4,8 @@ using Shouldly;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages;
 
+using TestContext = Bunit.TestContext;
+
 public class NotFoundPageTests : TestContext
 {
     [Fact]

--- a/EstateManagementUI.BlazorServer.Tests/Pages/PermissionsDebugPageTests.cs
+++ b/EstateManagementUI.BlazorServer.Tests/Pages/PermissionsDebugPageTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Shouldly;
 using System.Security.Claims;
+using TestContext = Bunit.TestContext;
 
 namespace EstateManagementUI.BlazorServer.Tests.Pages;
 

--- a/EstateManagementUI.BlazorServer/EstateManagementUI.BlazorServer.csproj
+++ b/EstateManagementUI.BlazorServer/EstateManagementUI.BlazorServer.csproj
@@ -12,17 +12,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.1" />
-    <PackageReference Include="Lamar" Version="15.0.1" />
-    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-    <PackageReference Include="MediatR" Version="14.0.0" />
-    <PackageReference Include="IdentityModel" Version="6.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.2" />
-    <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
-    <PackageReference Include="Shared.Results" Version="2026.5.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <PackageReference Include="Lamar" />
+    <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="IdentityModel" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+    <PackageReference Include="Sentry.AspNetCore" />
+    <PackageReference Include="Shared.Results" />
   </ItemGroup>
 
 

--- a/EstateManagementUI.IntegrationTests/EstateManagementUI.IntegrationTests.csproj
+++ b/EstateManagementUI.IntegrationTests/EstateManagementUI.IntegrationTests.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.0.0" />
-    <PackageReference Include="Reqnroll" Version="3.2.1" />
-    <PackageReference Include="Reqnroll.NUnit" Version="3.2.1" />
-    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.2.1" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Reqnroll" />
+    <PackageReference Include="Reqnroll.NUnit" />
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" />
+    <PackageReference Include="Microsoft.Playwright" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/EstateManagmentUI.BusinessLogic/EstateManagementUI.BusinessLogic.csproj
+++ b/EstateManagmentUI.BusinessLogic/EstateManagementUI.BusinessLogic.csproj
@@ -10,15 +10,15 @@
 	<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-		<PackageReference Include="FileProcessor.Client" Version="2026.5.1" />
-		<PackageReference Include="MediatR" Version="14.0.0" />
-		<PackageReference Include="SecurityService.Client" Version="2026.5.1" />
-		<PackageReference Include="Shared" Version="2026.5.6" />
-		<PackageReference Include="Shared.Results" Version="2026.5.6" />
-		<PackageReference Include="SimpleResults" Version="4.0.0" />
-		<PackageReference Include="TransactionProcessor.Client" Version="2026.5.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0" PrivateAssets="all" />
-		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="all" />
+		<PackageReference Include="ClientProxyBase" />
+		<PackageReference Include="FileProcessor.Client" />
+		<PackageReference Include="MediatR" />
+		<PackageReference Include="SecurityService.Client" />
+		<PackageReference Include="Shared" />
+		<PackageReference Include="Shared.Results" />
+		<PackageReference Include="SimpleResults" />
+		<PackageReference Include="TransactionProcessor.Client" />
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" />
+		<PackageReference Include="Roslynator.Analyzers" PrivateAssets="all" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Move all package versions to Directory.Packages.props for centralized management. Remove explicit version numbers from .csproj files and clean up redundant package references. Update test files to use explicit Bunit TestContext alias. Improves maintainability and consistency across the solution.

closes #1014 
closes #1015 