### PR TITLE
Add GitHub Actions workflow for Docker publish on main

### DIFF
--- a/.github/workflows/pushtomain.yml
+++ b/.github/workflows/pushtomain.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Publish Docker"

--- a/.github/workflows/pushtomain.yml
+++ b/.github/workflows/pushtomain.yml
@@ -1,0 +1,30 @@
+﻿name: Publish Docker
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+
+jobs:
+  build:
+    name: "Publish Docker"
+    env:
+        ASPNETCORE_ENVIRONMENT: "Production"
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2.3.4
+
+    - name: Restore Nuget Packages
+      run: dotnet restore EstateManagementUI.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} -r win-x64
+
+    - name: Build Code
+      run: dotnet build EstateManagementUI.sln --configuration Release --no-restore         
+    
+    - name: Publish Images to Docker Hub 
+      run: |
+        docker build . --file EstateManagementUI.BlazorServer/Dockerfile --tag stuartferguson/estatemanagementui:master
+        docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }}
+        docker push stuartferguson/estatemanagementui:master


### PR DESCRIPTION
Introduced pushtomain.yml to automate Docker image build and publish on pushes to the main branch. Workflow includes code checkout, NuGet package restore, solution build, Docker image creation, Docker Hub login, and image push with the "master" tag.

closes #1091 